### PR TITLE
FEST-465: isSubsetOf assertion

### DIFF
--- a/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
@@ -34,6 +34,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Mathieu Baechler
  * @author Joel Costigliola
+ * @author Maciej Jaskowski
  */
 public abstract class AbstractIterableAssert<S, A extends Iterable<?> > extends AbstractAssert<S, A> implements
     ObjectEnumerableAssert<S> {
@@ -78,6 +79,12 @@ public abstract class AbstractIterableAssert<S, A extends Iterable<?> > extends 
     return myself;
   }
 
+
+  public final S isSubsetOf(Iterable<?> values) {
+    iterables.assertIsSubsetOf(info, actual, values);
+    return myself;
+  }
+  
   /** {@inheritDoc} */
   public final S containsSequence(Object... sequence) {
     iterables.assertContainsSequence(info, actual, sequence);

--- a/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
@@ -79,7 +79,14 @@ public abstract class AbstractIterableAssert<S, A extends Iterable<?> > extends 
     return myself;
   }
 
-
+  /**
+   * Verifies that all the values of the actual iterable are present in the given values iterable.
+   * @param values the iterable of objects forming a set.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Iterable} is {@code null}.
+   * @throws NullPointerException if the set sequence is {@code null}.
+   * @throws AssertionError if the actual {@code Iterable} is not subset of set <code>{@link Iterable}</code>
+   */
   public final S isSubsetOf(Iterable<?> values) {
     iterables.assertIsSubsetOf(info, actual, values);
     return myself;

--- a/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
+++ b/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
@@ -1,0 +1,41 @@
+/*
+ * Created on Feb 18, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2012 the original author or authors.
+ */
+package org.fest.assertions.error;
+
+import org.fest.util.*;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a <code>{@link Iterable}</code> is
+ * a subset of an other set {@Iterable} failed.
+ * 
+ * @author Maciej Jaskowski
+ */
+public class ShouldBeSubsetOf extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldBeSubsetOf}</code>
+   * @param actual the actual set
+   * @param values the expected superset
+   * @param comparisonStrategy the <code>{@link ComparisonStrategy}</code> used
+   * @return the created <code>{@link ErrorMessageFactory}</code>
+   */
+  public static ErrorMessageFactory shouldBeSubsetOf(Object actual, Object values, ComparisonStrategy comparisonStrategy) {
+    return new ShouldBeSubsetOf(actual, values, comparisonStrategy);
+  }
+
+  private ShouldBeSubsetOf(Object actual, Object values, ComparisonStrategy comparisonStrategy) {
+    super("Expecting:<%s> to be subset of <%s>%s", actual, values, comparisonStrategy);
+  }
+}

--- a/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
+++ b/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
@@ -46,6 +46,6 @@ public class ShouldBeSubsetOf extends BasicErrorMessageFactory {
   }
 
   private ShouldBeSubsetOf(Object actual, Object values, Iterable<?> unexpected, ComparisonStrategy comparisonStrategy) {
-    super("Expecting:<%s> to be subset of <%s>%s but found those extra elements: <%s>", actual, values, comparisonStrategy, unexpected);
+    super("expecting:<%s> to be subset of <%s>%s but found those extra elements: <%s>", actual, values, comparisonStrategy, unexpected);
   }
 }

--- a/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
+++ b/src/main/java/org/fest/assertions/error/ShouldBeSubsetOf.java
@@ -31,11 +31,21 @@ public class ShouldBeSubsetOf extends BasicErrorMessageFactory {
    * @param comparisonStrategy the <code>{@link ComparisonStrategy}</code> used
    * @return the created <code>{@link ErrorMessageFactory}</code>
    */
-  public static ErrorMessageFactory shouldBeSubsetOf(Object actual, Object values, ComparisonStrategy comparisonStrategy) {
-    return new ShouldBeSubsetOf(actual, values, comparisonStrategy);
+  public static ErrorMessageFactory shouldBeSubsetOf(Object actual, Object values, Iterable<?> unexpected, ComparisonStrategy comparisonStrategy) {
+    return new ShouldBeSubsetOf(actual, values, unexpected, comparisonStrategy);
+  }
+  
+  /**
+   * Creates a new <code>{@link ShouldBeSubsetOf}</code>.
+   * @param actual the actual set
+   * @param values the expected superset
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldBeSubsetOf(Object actual, Object sequence, Iterable<?> unexpected) {
+    return new ShouldBeSubsetOf(actual, sequence, unexpected, StandardComparisonStrategy.instance());
   }
 
-  private ShouldBeSubsetOf(Object actual, Object values, ComparisonStrategy comparisonStrategy) {
-    super("Expecting:<%s> to be subset of <%s>%s", actual, values, comparisonStrategy);
+  private ShouldBeSubsetOf(Object actual, Object values, Iterable<?> unexpected, ComparisonStrategy comparisonStrategy) {
+    super("Expecting:<%s> to be subset of <%s>%s but found those extra elements: <%s>", actual, values, comparisonStrategy, unexpected);
   }
 }

--- a/src/main/java/org/fest/assertions/internal/Iterables.java
+++ b/src/main/java/org/fest/assertions/internal/Iterables.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.error.ShouldBeSubsetOf;
 import org.fest.util.ComparatorBasedComparisonStrategy;
 import org.fest.util.ComparisonStrategy;
 import org.fest.util.StandardComparisonStrategy;
@@ -47,6 +48,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Yvonne Wang
+ * @author Maciej Jaskowski
  */
 public class Iterables {
 
@@ -249,6 +251,34 @@ public class Iterables {
   }
 
   /**
+   * Verifies that the actual <code>{@link Iterable}</code> is a subset of set <code>{@link Iterable}</code>.
+   * <br/>Both actual and set are treated as sets, therefore duplicates on either of them are ignored. 
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code Iterable}.
+   * @param values the set {@code Iterable}.
+   * @throws AssertionError if the actual {@code Iterable} is {@code null}.
+   * @throws NullPointerException if the set sequence is {@code null}.
+   * @throws AssertionError if the actual {@code Iterable} is not subset of set <code>{@link Iterable}</code>
+   */
+  public void assertIsSubsetOf(AssertionInfo info, Iterable<?> actual, Iterable<?> values) {
+    assertNotNull(info, actual);
+    checkNotNull(info, values);
+    for (Object e : actual) {
+      if ( ! iterableContains(values, e)) {
+        throw actualIsNotSubsetOfSet(info, actual, values);
+      }
+    }
+  }
+
+  private void checkNotNull(AssertionInfo info, Iterable<?> set) {
+    if (set == null) throw arrayOfValuesToLookForIsNull();
+  }
+
+  private AssertionError actualIsNotSubsetOfSet(AssertionInfo info, Object actual, Iterable<?> set) {
+    return failures.failure(info, ShouldBeSubsetOf.shouldBeSubsetOf(actual, set, comparisonStrategy));
+  }
+
+/**
    * Return true if actualAsList contains exactly the given sequence at given starting index, false otherwise.
    * @param actualAsList the list to look sequance in 
    * @param sequence the sequence to look for

--- a/src/main/java/org/fest/assertions/internal/Iterables.java
+++ b/src/main/java/org/fest/assertions/internal/Iterables.java
@@ -27,6 +27,7 @@ import static org.fest.assertions.error.ShouldNotContain.shouldNotContain;
 import static org.fest.assertions.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.fest.assertions.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.fest.assertions.error.ShouldStartWith.shouldStartWith;
+import static org.fest.assertions.internal.CommonErrors.*;
 import static org.fest.util.Collections.*;
 
 import java.util.ArrayList;
@@ -425,10 +426,10 @@ public class Iterables {
     assertNotNull(info, actual);
     if (iterableContains(actual, null)) throw failures.failure(info, shouldNotContainNull(actual));
   }
-
+  
   private void checkIsNotNullAndNotEmpty(Object[] values) {
-    if (values == null) throw iterableToLookForIsNull();
-    if (values.length == 0) throw iterableToLookForIsEmpty();
+    if (values == null) throw arrayOfValuesToLookForIsNull();
+    if (values.length == 0) throw arrayOfValuesToLookForIsEmpty();
   }
 
   private void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/main/java/org/fest/assertions/internal/Iterables.java
+++ b/src/main/java/org/fest/assertions/internal/Iterables.java
@@ -27,9 +27,9 @@ import static org.fest.assertions.error.ShouldNotContain.shouldNotContain;
 import static org.fest.assertions.error.ShouldNotContainNull.shouldNotContainNull;
 import static org.fest.assertions.error.ShouldNotHaveDuplicates.shouldNotHaveDuplicates;
 import static org.fest.assertions.error.ShouldStartWith.shouldStartWith;
-import static org.fest.assertions.internal.CommonErrors.*;
 import static org.fest.util.Collections.*;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -263,19 +263,24 @@ public class Iterables {
   public void assertIsSubsetOf(AssertionInfo info, Iterable<?> actual, Iterable<?> values) {
     assertNotNull(info, actual);
     checkNotNull(info, values);
+    List<Object> extra = new ArrayList<Object>();
+    
     for (Object e : actual) {
       if ( ! iterableContains(values, e)) {
-        throw actualIsNotSubsetOfSet(info, actual, values);
+        extra.add(e);
       }
+    }
+    if (extra.size() > 0) {
+      throw actualIsNotSubsetOfSet(info, actual, values, extra);
     }
   }
 
   private void checkNotNull(AssertionInfo info, Iterable<?> set) {
-    if (set == null) throw arrayOfValuesToLookForIsNull();
+    if (set == null) throw iterableToLookForIsNull();
   }
 
-  private AssertionError actualIsNotSubsetOfSet(AssertionInfo info, Object actual, Iterable<?> set) {
-    return failures.failure(info, ShouldBeSubsetOf.shouldBeSubsetOf(actual, set, comparisonStrategy));
+  private AssertionError actualIsNotSubsetOfSet(AssertionInfo info, Object actual, Iterable<?> set, Iterable<?> extra) {
+    return failures.failure(info, ShouldBeSubsetOf.shouldBeSubsetOf(actual, set, extra, comparisonStrategy));
   }
 
 /**
@@ -422,8 +427,8 @@ public class Iterables {
   }
 
   private void checkIsNotNullAndNotEmpty(Object[] values) {
-    if (values == null) throw arrayOfValuesToLookForIsNull();
-    if (values.length == 0) throw arrayOfValuesToLookForIsEmpty();
+    if (values == null) throw iterableToLookForIsNull();
+    if (values.length == 0) throw iterableToLookForIsEmpty();
   }
 
   private void assertNotNull(AssertionInfo info, Iterable<?> actual) {
@@ -432,6 +437,14 @@ public class Iterables {
 
   private AssertionError actualDoesNotEndWithSequence(AssertionInfo info, Iterable<?> actual, Object[] sequence) {
     return failures.failure(info, shouldEndWith(actual, sequence, comparisonStrategy));
+  }
+  
+  static public NullPointerException iterableToLookForIsNull() {
+    return new NullPointerException("The iterable to look for should not be null");
+  }
+
+  static public IllegalArgumentException iterableToLookForIsEmpty() {
+    return new IllegalArgumentException("The iterable to look for should not be empty");
   }
 
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_isSubsetOf_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_isSubsetOf_Test.java
@@ -1,0 +1,46 @@
+/*
+ * Created on Feb 18, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import static org.fest.util.Collections.*;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link AbstractIterableAssert#isSubsetOf(Iterable)}</code>.
+ * 
+ * @author Alex Ruiz
+ * @author Joel Costigliola
+ * @author Maciej Jaskowski
+ */
+public class IterableAssert_isSubsetOf_Test extends AbstractTest_for_IterableAssert {
+
+  @Test
+  public void should_verify_that_actual_contains_given_values() {
+    List<String> values = list("Yoda", "Luke");
+    assertions.isSubsetOf(values);
+    verify(iterables).assertIsSubsetOf(assertions.info, assertions.actual, values);
+  }
+
+  @Test
+  public void should_return_this() {
+    ConcreteIterableAssert returned = assertions.isSubsetOf(list("Luke"));
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/error/ShouldBeSubsetOf_create_Test.java
+++ b/src/test/java/org/fest/assertions/error/ShouldBeSubsetOf_create_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Created on Nov 22, 2010
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2010-2011 the original author or authors.
+ */
+package org.fest.assertions.error;
+
+import static junit.framework.Assert.assertEquals;
+
+import static org.fest.assertions.error.ShouldBeSubsetOf.shouldBeSubsetOf;
+import static org.fest.util.Collections.list;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.fest.assertions.description.Description;
+import org.fest.assertions.description.TextDescription;
+import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.fest.util.ComparatorBasedComparisonStrategy;
+
+/**
+ * Tests for <code>{@link ShouldBeSubsetOf#create(Description)}</code>.
+ * 
+ * @author Maciej Jaskowski
+ */
+public class ShouldBeSubsetOf_create_Test {
+
+  private ErrorMessageFactory factory;
+
+  @Before
+  public void setUp() {
+    factory = shouldBeSubsetOf(list("Yoda", "Luke"), list("Han", "Luke"), list("Yoda"));
+  }
+
+  @Test
+  public void should_create_error_message() {
+    String message = factory.create(new TextDescription("Test"));
+    assertEquals("[Test] expecting:<['Yoda', 'Luke']> to be subset of <['Han', 'Luke']> but found those extra elements: <['Yoda']>", message);
+  }
+
+  @Test
+  public void should_create_error_message_with_custom_comparison_strategy() {
+    ErrorMessageFactory factory = shouldBeSubsetOf(list("Yoda", "Luke"), list("Han", "Luke"), list("Yoda"), 
+        new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    String message = factory.create(new TextDescription("Test"));
+    assertEquals("[Test] expecting:<['Yoda', 'Luke']> to be subset of <['Han', 'Luke']> "
+        + "according to 'CaseInsensitiveStringComparator' comparator but found those extra elements: <['Yoda']>", message);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Iterables_assertIsSubsetOf_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Iterables_assertIsSubsetOf_Test.java
@@ -1,0 +1,138 @@
+/*
+ * Created on Nov 22, 2010
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2010-2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.test.ErrorMessages.valuesToLookForIsNull;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.error.ShouldBeSubsetOf.*;
+import static org.fest.util.Arrays.array;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.*;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+/**
+ * Tests for <code>{@link Iterables#assertIsSubsetOf(AssertionInfo, Collection, Object[])}</code>.
+ * 
+ * @author Maciej Jaskowski
+ */
+public class Iterables_assertIsSubsetOf_Test extends AbstractTest_for_Iterables {
+
+  @Override
+  @Before
+  public void setUp() {
+    super.setUp();
+    actual = list("Yoda", "Luke");
+  }
+
+  @Test
+  public void should_pass_if_actual_is_subset_of_set() {
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Luke", "Yoda", "Obi-Wan"));
+  }
+  
+  @Test
+  public void should_pass_if_actual_has_the_same_elements_as_set() {
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Luke", "Yoda"));
+  }
+  
+  @Test
+  public void should_pass_if_actual_is_empty() {
+	  actual = list();
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Luke", "Yoda"));
+  }
+  
+  @Test
+  public void should_pass_if_actual_and_set_are_both_empty() {
+	  actual = list();
+	  iterables.assertIsSubsetOf(someInfo(), actual, list());
+  }
+  
+  @Test
+  public void should_pass_if_actual_has_duplicates_but_all_elements_are_in_values() {
+	  actual = list("Yoda", "Yoda");
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Yoda"));
+  }
+  
+  @Test
+  public void should_pass_if_values_has_duplicates_but_all_elements_are_in_values() {
+	  actual = list("Yoda", "C-3PO");
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Yoda", "Yoda", "C-3PO"));
+  }
+  
+  @Test
+  public void should_pass_if_both_actual_and_values_have_duplicates_but_all_elements_are_in_values() {
+	  actual = list("Yoda", "Yoda", "Yoda", "C-3PO", "Obi-Wan");
+	  iterables.assertIsSubsetOf(someInfo(), actual, list("Yoda", "Yoda", "C-3PO", "C-3PO", "Obi-Wan"));
+  }
+  
+  @Test
+  public void should_throw_error_if_set_is_null() {
+	  thrown.expectNullPointerException(valuesToLookForIsNull());
+	  iterables.assertIsSubsetOf(someInfo(), actual, null);
+  }
+  
+  @Test
+  public void should_throw_error_if_actual_is_null() {
+	  thrown.expectAssertionError(actualIsNull());
+	  iterables.assertIsSubsetOf(someInfo(), null, list());
+  }
+  
+  
+  //duplicates in actual ; duplicates in values; duplicates in both
+
+  // ------------------------------------------------------------------------------------------------------------------
+  // tests using a custom comparison strategy
+  // ------------------------------------------------------------------------------------------------------------------
+
+  @Test
+  public void should_pass_if_actual_is_subset_of_values_according_to_custom_comparison_strategy() {
+    iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(someInfo(), actual, list("yoda", "lUKE" ));
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_duplicates_according_to_custom_comparison_strategy() {
+    actual = list("Luke", "Luke");
+    iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(someInfo(), actual, list("LUke", "yoda"));
+  }
+
+  @Test
+  public void should_pass_if_actual_contains_given_values_even_if_duplicated_according_to_custom_comparison_strategy() {
+    iterablesWithCaseInsensitiveComparisonStrategy.assertContains(someInfo(), actual, array("LUke", "LuKe", "yoda"));
+  }
+  
+  @Test
+  public void should_fail_if_actual_is_not_subset_of_values_according_to_custom_comparison_strategy() {
+    AssertionInfo info = someInfo();
+    List<String> values = list("yoda", "C-3PO" );
+    try {
+      iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(info, actual, values);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldBeSubsetOf(actual, values, comparisonStrategy));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+
+}

--- a/src/test/java/org/fest/assertions/internal/Iterables_assertIsSubsetOf_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Iterables_assertIsSubsetOf_Test.java
@@ -14,21 +14,19 @@
  */
 package org.fest.assertions.internal;
 
-import static org.fest.assertions.test.ErrorMessages.valuesToLookForIsNull;
+import static org.fest.assertions.error.ShouldBeSubsetOf.shouldBeSubsetOf;
+import static org.fest.assertions.test.ErrorMessages.iterableToLookForIsNull;
 import static org.fest.assertions.test.FailureMessages.actualIsNull;
 import static org.fest.assertions.test.TestData.someInfo;
-import static org.fest.assertions.error.ShouldBeSubsetOf.*;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
 import static org.fest.util.Arrays.array;
 import static org.fest.util.Collections.list;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import java.util.Collection;
 import java.util.List;
 
 import org.fest.assertions.core.AssertionInfo;
-import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
-
-import org.junit.Before;
 import org.junit.Test;
 
 
@@ -39,20 +37,15 @@ import org.junit.Test;
  */
 public class Iterables_assertIsSubsetOf_Test extends AbstractTest_for_Iterables {
 
-  @Override
-  @Before
-  public void setUp() {
-    super.setUp();
-    actual = list("Yoda", "Luke");
-  }
-
   @Test
   public void should_pass_if_actual_is_subset_of_set() {
+	  actual = list("Yoda", "Luke");
 	  iterables.assertIsSubsetOf(someInfo(), actual, list("Luke", "Yoda", "Obi-Wan"));
   }
   
   @Test
   public void should_pass_if_actual_has_the_same_elements_as_set() {
+	  actual = list("Yoda", "Luke");
 	  iterables.assertIsSubsetOf(someInfo(), actual, list("Luke", "Yoda"));
   }
   
@@ -88,18 +81,33 @@ public class Iterables_assertIsSubsetOf_Test extends AbstractTest_for_Iterables 
   
   @Test
   public void should_throw_error_if_set_is_null() {
-	  thrown.expectNullPointerException(valuesToLookForIsNull());
+	  actual = list("Yoda", "Luke");
+	  thrown.expectNullPointerException(iterableToLookForIsNull());
 	  iterables.assertIsSubsetOf(someInfo(), actual, null);
   }
   
   @Test
   public void should_throw_error_if_actual_is_null() {
+	  actual = null;
 	  thrown.expectAssertionError(actualIsNull());
-	  iterables.assertIsSubsetOf(someInfo(), null, list());
+	  iterables.assertIsSubsetOf(someInfo(), actual, list());
   }
   
+  @Test
+  public void should_fail_if_actual_is_not_subset_of_values() {
+      AssertionInfo info = someInfo();
+      actual = list("Yoda");	  
+      List<String> values = list("C-3PO", "Leila");
+      List<String> extra = list("Yoda");
+      try {
+        iterables.assertIsSubsetOf(info, actual, values);
+      } catch (AssertionError e) {	      
+        verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra));
+        return;
+      }
+      failBecauseExpectedAssertionErrorWasNotThrown();
+  }
   
-  //duplicates in actual ; duplicates in values; duplicates in both
 
   // ------------------------------------------------------------------------------------------------------------------
   // tests using a custom comparison strategy
@@ -107,6 +115,7 @@ public class Iterables_assertIsSubsetOf_Test extends AbstractTest_for_Iterables 
 
   @Test
   public void should_pass_if_actual_is_subset_of_values_according_to_custom_comparison_strategy() {
+    actual = list("Yoda", "Luke");
     iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(someInfo(), actual, list("yoda", "lUKE" ));
   }
 
@@ -118,21 +127,23 @@ public class Iterables_assertIsSubsetOf_Test extends AbstractTest_for_Iterables 
 
   @Test
   public void should_pass_if_actual_contains_given_values_even_if_duplicated_according_to_custom_comparison_strategy() {
+	actual = list("Yoda", "Luke");
     iterablesWithCaseInsensitiveComparisonStrategy.assertContains(someInfo(), actual, array("LUke", "LuKe", "yoda"));
   }
   
   @Test
   public void should_fail_if_actual_is_not_subset_of_values_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
+    actual = list("Yoda", "Luke");
     List<String> values = list("yoda", "C-3PO" );
+    List<String> extra = list("Luke");
     try {
       iterablesWithCaseInsensitiveComparisonStrategy.assertIsSubsetOf(info, actual, values);
     } catch (AssertionError e) {
-      verify(failures).failure(info, shouldBeSubsetOf(actual, values, comparisonStrategy));
+      verify(failures).failure(info, shouldBeSubsetOf(actual, values, extra, comparisonStrategy));
       return;
     }
     failBecauseExpectedAssertionErrorWasNotThrown();
   }
-
 
 }

--- a/src/test/java/org/fest/assertions/test/ErrorMessages.java
+++ b/src/test/java/org/fest/assertions/test/ErrorMessages.java
@@ -57,6 +57,10 @@ public final class ErrorMessages {
   public static String isNotArray(Object o) {
     return String.format("The object <%s> should be an array", toStringOf(o));
   }
+  
+  public static String iterableToLookForIsNull() {
+    return "The iterable to look for should not be null";
+  }
 
   public static String offsetIsNull() {
     return "The given offset should not be null";


### PR DESCRIPTION
Hi Alex,

I have the "isSubsetOf" assertion working :-)

The only thing I couldn't make working is JavaDoc on AbstractIterableAssert.isSubsetOf(). I just couldn't figure out how the {@inheritDoc} magic works.

Apart from that I created tests for both AbstractIterableAssert and Iterables. I named the test methods the best I could. Feel free, however, to make them suite your taste :)

I did also the assumption that we are speaking about sets not multisets. Therefore if we have duplicates on either side, they are seen as one.

Let me know if anything needs my further attention.
Best,
Maciej
