### PR TITLE
Improve type safety and fix comparators

### DIFF
--- a/src/main/java/org/fest/assertions/api/AbstractAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractAssert.java
@@ -190,13 +190,13 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
     this.objects = Objects.instance();
     return myself;
   }
-  
+
   /** {@inheritDoc} */
   @Override 
   public final boolean equals(Object obj) {
     throw new UnsupportedOperationException("'equals' is not supported...maybe you intended to call 'isEqualTo'");
   }  
-  
+
   /**
    * Always returns 1.
    * @return 1.

--- a/src/main/java/org/fest/assertions/api/AbstractAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractAssert.java
@@ -178,7 +178,7 @@ public abstract class AbstractAssert<S extends AbstractAssert<S, A>, A> implemen
   }
 
   /** {@inheritDoc} */
-  public S usingComparator(Comparator<?> customComparator) {  
+  public S usingComparator(Comparator<? super A> customComparator) {  
     // using a specific strategy to compare actual with other objects.
     this.objects = new Objects(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/AbstractComparableAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractComparableAssert.java
@@ -66,7 +66,7 @@ public abstract class AbstractComparableAssert<S extends AbstractComparableAsser
   }
 
   @Override
-  public S usingComparator(Comparator<?> customComparator) {
+  public S usingComparator(Comparator<? super A> customComparator) {
     super.usingComparator(customComparator);
     this.comparables = new Comparables(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
@@ -247,16 +247,12 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
     return myself;
   }
 
-  @Override
-  public S usingComparator(Comparator<? super A> customComparator) {
-    super.usingComparator(customComparator);
+  public S usingElementComparator(Comparator<? super T> customComparator) {
     this.iterables = new Iterables(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
 
-  @Override
-  public S usingDefaultComparator() {
-    super.usingDefaultComparator();
+  public S usingDefaultElementComparator() {
     this.iterables = Iterables.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/AbstractIterableAssert.java
@@ -30,6 +30,7 @@ import org.fest.util.VisibleForTesting;
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <A> the type of the "actual" value.
+ * @param <T> the type of elements of the "actual" value.
  * 
  * @author Yvonne Wang
  * @author Alex Ruiz
@@ -39,8 +40,8 @@ import org.fest.util.VisibleForTesting;
  * @author Nicolas François
  * @author Mikhail Mazursky
  */
-public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S, A>, A extends Iterable<?>> extends
-    AbstractAssert<S, A> implements ObjectEnumerableAssert<S> {
+public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S, A, T>, A extends Iterable<T>, T> extends
+    AbstractAssert<S, A> implements ObjectEnumerableAssert<S, T> {
 
   @VisibleForTesting
   Iterables iterables = Iterables.instance();
@@ -84,13 +85,13 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
   }
 
   /** {@inheritDoc} */
-  public final S contains(Object... values) {
+  public final S contains(T... values) {
     iterables.assertContains(info, actual, values);
     return myself;
   }
 
   /** {@inheritDoc} */
-  public final S containsOnly(Object... values) {
+  public final S containsOnly(T... values) {
     iterables.assertContainsOnly(info, actual, values);
     return myself;
   }
@@ -103,19 +104,19 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
    * @throws NullPointerException if the given {@code Iterable} is {@code null}.
    * @throws AssertionError if the actual {@code Iterable} is not subset of set {@code Iterable}.
    */
-  public final S isSubsetOf(Iterable<?> values) {
+  public final S isSubsetOf(Iterable<? extends T> values) {
     iterables.assertIsSubsetOf(info, actual, values);
     return myself;
   }
 
   /** {@inheritDoc} */
-  public final S containsSequence(Object... sequence) {
+  public final S containsSequence(T... sequence) {
     iterables.assertContainsSequence(info, actual, sequence);
     return myself;
   }
 
   /** {@inheritDoc} */
-  public final S doesNotContain(Object... values) {
+  public final S doesNotContain(T... values) {
     iterables.assertDoesNotContain(info, actual, values);
     return myself;
   }
@@ -127,13 +128,13 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
   }
 
   /** {@inheritDoc} */
-  public final S startsWith(Object... sequence) {
+  public final S startsWith(T... sequence) {
     iterables.assertStartsWith(info, actual, sequence);
     return myself;
   }
 
   /** {@inheritDoc} */
-  public final S endsWith(Object... sequence) {
+  public final S endsWith(T... sequence) {
     iterables.assertEndsWith(info, actual, sequence);
     return myself;
   }
@@ -247,7 +248,7 @@ public abstract class AbstractIterableAssert<S extends AbstractIterableAssert<S,
   }
 
   @Override
-  public S usingComparator(Comparator<?> customComparator) {
+  public S usingComparator(Comparator<? super A> customComparator) {
     super.usingComparator(customComparator);
     this.iterables = new Iterables(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/Assertions.java
+++ b/src/main/java/org/fest/assertions/api/Assertions.java
@@ -53,6 +53,7 @@ import org.fest.assertions.util.ImageReader;
  * @author Ted Young
  * @author Joel Costigliola
  * @author Matthieu Baechler
+ * @author Mikhail Mazursky
  */
 public class Assertions {
 
@@ -161,8 +162,8 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static IterableAssert assertThat(Iterable<?> actual) {
-    return new IterableAssert(actual);
+  public static <T> IterableAssert<T> assertThat(Iterable<T> actual) {
+    return new IterableAssert<T>(actual);
   }
 
   /**
@@ -269,8 +270,8 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ListAssert assertThat(List<?> actual) {
-    return new ListAssert(actual);
+  public static <T> ListAssert<T> assertThat(List<T> actual) {
+    return new ListAssert<T>(actual);
   }
 
   /**

--- a/src/main/java/org/fest/assertions/api/Assertions.java
+++ b/src/main/java/org/fest/assertions/api/Assertions.java
@@ -306,8 +306,8 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ObjectAssert assertThat(Object actual) {
-    return new ObjectAssert(actual);
+  public static <T> ObjectAssert<T> assertThat(T actual) {
+    return new ObjectAssert<T>(actual);
   }
 
   /**
@@ -315,8 +315,8 @@ public class Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ObjectArrayAssert assertThat(Object[] actual) {
-    return new ObjectArrayAssert(actual);
+  public static <T> ObjectArrayAssert<T> assertThat(T[] actual) {
+    return new ObjectArrayAssert<T>(actual);
   }
 
   /**
@@ -440,8 +440,8 @@ public class Assertions {
    * assertThat(extractProperty("race.name").from(fellowshipOfTheRing)).contains("Hobbit", "Elf").doesNotContain("Orc");
    * </pre>
    */
-  public static Properties extractProperty(String propertyName) {
-    return Properties.extractProperty(propertyName);
+  public static <T> Properties<T> extractProperty(String propertyName, Class<T> propertyType) {
+    return Properties.extractProperty(propertyName, propertyType);
   }
 
   // ------------------------------------------------------------------------------------------------------

--- a/src/main/java/org/fest/assertions/api/BigDecimalAssert.java
+++ b/src/main/java/org/fest/assertions/api/BigDecimalAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.*;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class BigDecimalAssert extends AbstractUnevenComparableAssert<BigDecimalAssert, BigDecimal> implements
     NumberAssert<BigDecimal> {
@@ -67,7 +68,7 @@ public class BigDecimalAssert extends AbstractUnevenComparableAssert<BigDecimalA
   }
 
   @Override
-  public BigDecimalAssert usingComparator(Comparator<?> customComparator) {
+  public BigDecimalAssert usingComparator(Comparator<? super BigDecimal> customComparator) {
     super.usingComparator(customComparator);
     this.bigDecimals = new BigDecimals(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
@@ -31,6 +31,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boolean[]> implements
     EnumerableAssert<BooleanArrayAssert>, ArraySortedAssert<BooleanArrayAssert, Boolean> {
@@ -200,13 +201,13 @@ public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boole
   }
 
   /** {@inheritDoc} */
-  public BooleanArrayAssert isSortedAccordingTo(Comparator<? extends Boolean> comparator) {
+  public BooleanArrayAssert isSortedAccordingTo(Comparator<? super Boolean> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public BooleanArrayAssert usingComparator(Comparator<?> customComparator) {
+  public BooleanArrayAssert usingComparator(Comparator<? super boolean[]> customComparator) {
     throw new UnsupportedOperationException("custom Comparator is not supported for Boolean array comparison");
   }
 }

--- a/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
@@ -34,7 +34,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  */
 public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boolean[]> implements
-    EnumerableAssert<BooleanArrayAssert>, ArraySortedAssert<BooleanArrayAssert, Boolean> {
+    EnumerableAssert<BooleanArrayAssert, Boolean>, ArraySortedAssert<BooleanArrayAssert, Boolean> {
 
   @VisibleForTesting
   BooleanArrays arrays = BooleanArrays.instance();
@@ -206,8 +206,13 @@ public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boole
     return this;
   }
 
-  @Override
-  public BooleanArrayAssert usingComparator(Comparator<? super boolean[]> customComparator) {
-    throw new UnsupportedOperationException("custom Comparator is not supported for Boolean array comparison");
+  /** {@inheritDoc} */
+  public BooleanArrayAssert usingElementComparator(Comparator<? super Boolean> customComparator) {
+    throw new UnsupportedOperationException("custom element Comparator is not supported for Boolean array comparison");
+  }
+
+  /** {@inheritDoc} */
+  public BooleanArrayAssert usingDefaultElementComparator() {
+    throw new UnsupportedOperationException("custom element Comparator is not supported for Boolean array comparison");
   }
 }

--- a/src/main/java/org/fest/assertions/api/BooleanAssert.java
+++ b/src/main/java/org/fest/assertions/api/BooleanAssert.java
@@ -30,6 +30,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author David DIDIER
  * @author Ansgar Konermann
+ * @author Mikhail Mazursky
  */
 public class BooleanAssert extends AbstractAssert<BooleanAssert, Boolean> {
 
@@ -85,7 +86,7 @@ public class BooleanAssert extends AbstractAssert<BooleanAssert, Boolean> {
   }
 
   @Override
-  public BooleanAssert usingComparator(Comparator<?> customComparator) {
+  public BooleanAssert usingComparator(Comparator<? super Boolean> customComparator) {
     throw new UnsupportedOperationException("custom Comparator is not supported for Boolean comparison");
   }
 }

--- a/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
@@ -32,10 +32,11 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> implements
     EnumerableAssert<ByteArrayAssert>, ArraySortedAssert<ByteArrayAssert, Byte> {
-  
+
   @VisibleForTesting
   ByteArrays arrays = ByteArrays.instance();
 
@@ -201,13 +202,13 @@ public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> imp
   }
 
   /** {@inheritDoc} */
-  public ByteArrayAssert isSortedAccordingTo(Comparator<? extends Byte> comparator) {
+  public ByteArrayAssert isSortedAccordingTo(Comparator<? super Byte> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public ByteArrayAssert usingComparator(Comparator<?> customComparator) {
+  public ByteArrayAssert usingComparator(Comparator<? super byte[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new ByteArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
@@ -35,7 +35,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  */
 public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> implements
-    EnumerableAssert<ByteArrayAssert>, ArraySortedAssert<ByteArrayAssert, Byte> {
+    EnumerableAssert<ByteArrayAssert, Byte>, ArraySortedAssert<ByteArrayAssert, Byte> {
 
   @VisibleForTesting
   ByteArrays arrays = ByteArrays.instance();
@@ -207,16 +207,14 @@ public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> imp
     return this;
   }
 
-  @Override
-  public ByteArrayAssert usingComparator(Comparator<? super byte[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public ByteArrayAssert usingElementComparator(Comparator<? super Byte> customComparator) {
     this.arrays = new ByteArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
 
-  @Override
-  public ByteArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+  /** {@inheritDoc} */
+  public ByteArrayAssert usingDefaultElementComparator() {
     this.arrays = ByteArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/ByteAssert.java
+++ b/src/main/java/org/fest/assertions/api/ByteAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author David DIDIER
  * @author Ansgar Konermann
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ByteAssert extends AbstractComparableAssert<ByteAssert, Byte> implements NumberAssert<Byte> {
 
@@ -138,7 +139,7 @@ public class ByteAssert extends AbstractComparableAssert<ByteAssert, Byte> imple
   }
 
   @Override
-  public ByteAssert usingComparator(Comparator<?> customComparator) {
+  public ByteAssert usingComparator(Comparator<? super Byte> customComparator) {
     super.usingComparator(customComparator);
     this.bytes = new Bytes(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/CharArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/CharArrayAssert.java
@@ -35,7 +35,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  */
 public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> implements
-    EnumerableAssert<CharArrayAssert>, ArraySortedAssert<CharArrayAssert, Character> {
+    EnumerableAssert<CharArrayAssert, Character>, ArraySortedAssert<CharArrayAssert, Character> {
 
   @VisibleForTesting
   CharArrays arrays = CharArrays.instance();
@@ -207,16 +207,14 @@ public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> imp
     return this;
   }
 
-  @Override
-  public CharArrayAssert usingComparator(Comparator<? super char[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public CharArrayAssert usingElementComparator(Comparator<? super Character> customComparator) {
     this.arrays = new CharArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public CharArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  /** {@inheritDoc} */
+  public CharArrayAssert usingDefaultElementComparator() {
     this.arrays = CharArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/CharArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/CharArrayAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> implements
     EnumerableAssert<CharArrayAssert>, ArraySortedAssert<CharArrayAssert, Character> {
@@ -201,13 +202,13 @@ public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> imp
   }
 
   /** {@inheritDoc} */
-  public CharArrayAssert isSortedAccordingTo(Comparator<? extends Character> comparator) {
+  public CharArrayAssert isSortedAccordingTo(Comparator<? super Character> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public CharArrayAssert usingComparator(Comparator<?> customComparator) {
+  public CharArrayAssert usingComparator(Comparator<? super char[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new CharArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/CharacterAssert.java
+++ b/src/main/java/org/fest/assertions/api/CharacterAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Ansgar Konermann
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class CharacterAssert extends AbstractComparableAssert<CharacterAssert, Character> {
 
@@ -136,7 +137,7 @@ public class CharacterAssert extends AbstractComparableAssert<CharacterAssert, C
   }
 
   @Override
-  public CharacterAssert usingComparator(Comparator<?> customComparator) {
+  public CharacterAssert usingComparator(Comparator<? super Character> customComparator) {
     super.usingComparator(customComparator);
     this.characters = new Characters(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/DateAssert.java
+++ b/src/main/java/org/fest/assertions/api/DateAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Tomasz Nurkiewicz (thanks for giving assertions idea)
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class DateAssert extends AbstractAssert<DateAssert, Date> {
 
@@ -877,7 +878,7 @@ public class DateAssert extends AbstractAssert<DateAssert, Date> {
   }
 
   @Override
-  public DateAssert usingComparator(Comparator<?> customComparator) {
+  public DateAssert usingComparator(Comparator<? super Date> customComparator) {
     super.usingComparator(customComparator);
     this.dates = new Dates(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
@@ -16,10 +16,12 @@ package org.fest.assertions.api;
 
 import java.util.Comparator;
 
-import org.fest.assertions.core.*;
+import org.fest.assertions.core.ArraySortedAssert;
+import org.fest.assertions.core.EnumerableAssert;
 import org.fest.assertions.data.Index;
 import org.fest.assertions.internal.DoubleArrays;
-import org.fest.util.*;
+import org.fest.util.ComparatorBasedComparisonStrategy;
+import org.fest.util.VisibleForTesting;
 
 /**
  * Assertion methods for arrays of {@code double}s.
@@ -33,7 +35,7 @@ import org.fest.util.*;
  * @author Mikhail Mazursky
  */
 public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[]> implements
-    EnumerableAssert<DoubleArrayAssert>, ArraySortedAssert<DoubleArrayAssert, Double> {
+    EnumerableAssert<DoubleArrayAssert, Double>, ArraySortedAssert<DoubleArrayAssert, Double> {
 
   @VisibleForTesting
   DoubleArrays arrays = DoubleArrays.instance();
@@ -204,18 +206,17 @@ public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
-  
-  @Override
-  public DoubleArrayAssert usingComparator(Comparator<? super double[]> customComparator) {
-    super.usingComparator(customComparator);
+
+  /** {@inheritDoc} */
+  public DoubleArrayAssert usingElementComparator(Comparator<? super Double> customComparator) {
     this.arrays = new DoubleArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public DoubleArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  /** {@inheritDoc} */
+  public DoubleArrayAssert usingDefaultElementComparator() {
     this.arrays = DoubleArrays.instance();
     return myself;
   }
+
 }

--- a/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
@@ -30,6 +30,7 @@ import org.fest.util.*;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[]> implements
     EnumerableAssert<DoubleArrayAssert>, ArraySortedAssert<DoubleArrayAssert, Double> {
@@ -199,13 +200,13 @@ public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[
   }
 
   /** {@inheritDoc} */
-  public DoubleArrayAssert isSortedAccordingTo(Comparator<? extends Double> comparator) {
+  public DoubleArrayAssert isSortedAccordingTo(Comparator<? super Double> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
   
   @Override
-  public DoubleArrayAssert usingComparator(Comparator<?> customComparator) {
+  public DoubleArrayAssert usingComparator(Comparator<? super double[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new DoubleArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/DoubleAssert.java
+++ b/src/main/java/org/fest/assertions/api/DoubleAssert.java
@@ -34,6 +34,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Ansgar Konermann
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class DoubleAssert extends AbstractComparableAssert<DoubleAssert, Double> implements
     FloatingPointNumberAssert<Double> {
@@ -174,7 +175,7 @@ public class DoubleAssert extends AbstractComparableAssert<DoubleAssert, Double>
   }
 
   @Override
-  public DoubleAssert usingComparator(Comparator<?> customComparator) {
+  public DoubleAssert usingComparator(Comparator<? super Double> customComparator) {
     super.usingComparator(customComparator);
     this.doubles = new Doubles(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
@@ -16,10 +16,12 @@ package org.fest.assertions.api;
 
 import java.util.Comparator;
 
-import org.fest.assertions.core.*;
+import org.fest.assertions.core.ArraySortedAssert;
+import org.fest.assertions.core.EnumerableAssert;
 import org.fest.assertions.data.Index;
 import org.fest.assertions.internal.FloatArrays;
-import org.fest.util.*;
+import org.fest.util.ComparatorBasedComparisonStrategy;
+import org.fest.util.VisibleForTesting;
 
 /**
  * Assertion methods for arrays of {@code float}s.
@@ -33,7 +35,7 @@ import org.fest.util.*;
  * @author Mikhail Mazursky
  */
 public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> implements
-    EnumerableAssert<FloatArrayAssert>, ArraySortedAssert<FloatArrayAssert, Float> {
+    EnumerableAssert<FloatArrayAssert, Float>, ArraySortedAssert<FloatArrayAssert, Float> {
 
   @VisibleForTesting
   FloatArrays arrays = FloatArrays.instance();
@@ -205,16 +207,14 @@ public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> 
     return this;
   }
 
-  @Override
-  public FloatArrayAssert usingComparator(Comparator<? super float[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public FloatArrayAssert usingElementComparator(Comparator<? super Float> customComparator) {
     this.arrays = new FloatArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public FloatArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  /** {@inheritDoc} */
+  public FloatArrayAssert usingDefaultElementComparator() {
     this.arrays = FloatArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
@@ -30,6 +30,7 @@ import org.fest.util.*;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> implements
     EnumerableAssert<FloatArrayAssert>, ArraySortedAssert<FloatArrayAssert, Float> {
@@ -199,13 +200,13 @@ public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> 
   }
 
   /** {@inheritDoc} */
-  public FloatArrayAssert isSortedAccordingTo(Comparator<? extends Float> comparator) {
+  public FloatArrayAssert isSortedAccordingTo(Comparator<? super Float> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public FloatArrayAssert usingComparator(Comparator<?> customComparator) {
+  public FloatArrayAssert usingComparator(Comparator<? super float[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new FloatArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/FloatAssert.java
+++ b/src/main/java/org/fest/assertions/api/FloatAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Ansgar Konermann
+ * @author Mikhail Mazursky
  */
 public class FloatAssert extends AbstractComparableAssert<FloatAssert, Float> implements FloatingPointNumberAssert<Float> {
 
@@ -170,7 +171,7 @@ public class FloatAssert extends AbstractComparableAssert<FloatAssert, Float> im
   }
 
   @Override
-  public FloatAssert usingComparator(Comparator<?> customComparator) {
+  public FloatAssert usingComparator(Comparator<? super Float> customComparator) {
     super.usingComparator(customComparator);
     this.floats = new Floats(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/ImageAssert.java
+++ b/src/main/java/org/fest/assertions/api/ImageAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Ansgar Konermann
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ImageAssert extends AbstractAssert<ImageAssert, BufferedImage> {
 
@@ -97,7 +98,7 @@ public class ImageAssert extends AbstractAssert<ImageAssert, BufferedImage> {
   }
 
   @Override
-  public ImageAssert usingComparator(Comparator<?> customComparator) {
+  public ImageAssert usingComparator(Comparator<? super BufferedImage> customComparator) {
     throw new UnsupportedOperationException("custom Comparator is not supported for image comparison");
   }
 

--- a/src/main/java/org/fest/assertions/api/IntArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/IntArrayAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implements EnumerableAssert<IntArrayAssert>,
     ArraySortedAssert<IntArrayAssert, Integer> {
@@ -201,13 +202,13 @@ public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implem
   }
 
   /** {@inheritDoc} */
-  public IntArrayAssert isSortedAccordingTo(Comparator<? extends Integer> comparator) {
+  public IntArrayAssert isSortedAccordingTo(Comparator<? super Integer> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public IntArrayAssert usingComparator(Comparator<?> customComparator) {
+  public IntArrayAssert usingComparator(Comparator<? super int[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new IntArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/IntArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/IntArrayAssert.java
@@ -34,7 +34,7 @@ import org.fest.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  */
-public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implements EnumerableAssert<IntArrayAssert>,
+public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implements EnumerableAssert<IntArrayAssert, Integer>,
     ArraySortedAssert<IntArrayAssert, Integer> {
 
   @VisibleForTesting
@@ -207,16 +207,14 @@ public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implem
     return this;
   }
 
-  @Override
-  public IntArrayAssert usingComparator(Comparator<? super int[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public IntArrayAssert usingElementComparator(Comparator<? super Integer> customComparator) {
     this.arrays = new IntArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public IntArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  /** {@inheritDoc} */
+  public IntArrayAssert usingDefaultElementComparator() {
     this.arrays = IntArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/IntegerAssert.java
+++ b/src/main/java/org/fest/assertions/api/IntegerAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Ansgar Konermann
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class IntegerAssert extends AbstractComparableAssert<IntegerAssert, Integer> implements NumberAssert<Integer> {
 
@@ -139,7 +140,7 @@ public class IntegerAssert extends AbstractComparableAssert<IntegerAssert, Integ
   }
 
   @Override
-  public IntegerAssert usingComparator(Comparator<?> customComparator) {
+  public IntegerAssert usingComparator(Comparator<? super Integer> customComparator) {
     super.usingComparator(customComparator);
     this.integers = new Integers(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/IterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/IterableAssert.java
@@ -25,10 +25,11 @@ package org.fest.assertions.api;
  * @author Alex Ruiz
  * @author Matthieu Baechler
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
-public class IterableAssert extends AbstractIterableAssert<IterableAssert, Iterable<?> >  {
+public class IterableAssert<T> extends AbstractIterableAssert<IterableAssert<T>, Iterable<T>, T>  {
 
-  protected IterableAssert(Iterable<?>  actual) {
+  protected IterableAssert(Iterable<T>  actual) {
     super(actual, IterableAssert.class);
   }
 }

--- a/src/main/java/org/fest/assertions/api/ListAssert.java
+++ b/src/main/java/org/fest/assertions/api/ListAssert.java
@@ -32,25 +32,26 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 // TODO inherits from IterableAssert and remove AbstractIterableAssert ? 
-public class ListAssert extends AbstractIterableAssert<ListAssert, List<?>> implements IndexedObjectEnumerableAssert {
+public class ListAssert<T> extends AbstractIterableAssert<ListAssert<T>, List<T>, T> implements IndexedObjectEnumerableAssert<T> {
 
   @VisibleForTesting
   Lists lists = Lists.instance();
 
-  protected ListAssert(List<?> actual) {
+  protected ListAssert(List<T> actual) {
     super(actual, ListAssert.class);
   }
 
   /** {@inheritDoc} */
-  public ListAssert contains(Object value, Index index) {
+  public ListAssert<T> contains(T value, Index index) {
     lists.assertContains(info, actual, value, index);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ListAssert doesNotContain(Object value, Index index) {
+  public ListAssert<T> doesNotContain(T value, Index index) {
     lists.assertDoesNotContain(info, actual, value, index);
     return this;
   }
@@ -76,7 +77,7 @@ public class ListAssert extends AbstractIterableAssert<ListAssert, List<?>> impl
    * @throws AssertionError if the actual list element type does not implement {@link Comparable}.
    * @throws AssertionError if the actual list elements are not mutually {@link Comparable}.
    */
-  public ListAssert isSorted() {
+  public ListAssert<T> isSorted() {
     lists.assertIsSorted(info, actual); 
     return this;
   }
@@ -92,22 +93,22 @@ public class ListAssert extends AbstractIterableAssert<ListAssert, List<?>> impl
    * @throws AssertionError if the actual list is not sorted according to the given comparator.
    * @throws AssertionError if the actual list is <code>null</code>.
    * @throws NullPointerException if the given comparator is <code>null</code>.
-   * @throws AssertionError if the actual list elements are not mutually comparabe according to given Comparator.
+   * @throws AssertionError if the actual list elements are not mutually comparable according to given Comparator.
    */
-  public ListAssert isSortedAccordingTo(Comparator<? extends Object> comparator) {
+  public ListAssert<T> isSortedAccordingTo(Comparator<? super T> comparator) {
     lists.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public ListAssert usingComparator(Comparator<?> customComparator) {
+  public ListAssert<T> usingComparator(Comparator<? super List<T>> customComparator) {
     super.usingComparator(customComparator);
     this.lists = new Lists(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
+
   @Override
-  public ListAssert usingDefaultComparator() {
+  public ListAssert<T> usingDefaultComparator() {
     super.usingDefaultComparator();
     this.lists = Lists.instance();
     return myself;

--- a/src/main/java/org/fest/assertions/api/ListAssert.java
+++ b/src/main/java/org/fest/assertions/api/ListAssert.java
@@ -101,15 +101,15 @@ public class ListAssert<T> extends AbstractIterableAssert<ListAssert<T>, List<T>
   }
 
   @Override
-  public ListAssert<T> usingComparator(Comparator<? super List<T>> customComparator) {
-    super.usingComparator(customComparator);
+  public ListAssert<T> usingElementComparator(Comparator<? super T> customComparator) {
+    super.usingElementComparator(customComparator);
     this.lists = new Lists(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
 
   @Override
-  public ListAssert<T> usingDefaultComparator() {
-    super.usingDefaultComparator();
+  public ListAssert<T> usingDefaultElementComparator() {
+    super.usingDefaultElementComparator();
     this.lists = Lists.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/LongArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/LongArrayAssert.java
@@ -35,7 +35,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  */
 public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> implements
-    EnumerableAssert<LongArrayAssert>, ArraySortedAssert<LongArrayAssert, Long> {
+    EnumerableAssert<LongArrayAssert, Long>, ArraySortedAssert<LongArrayAssert, Long> {
 
   @VisibleForTesting
   LongArrays arrays = LongArrays.instance();
@@ -207,16 +207,14 @@ public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> imp
     return this;
   }
 
-  @Override
-  public LongArrayAssert usingComparator(Comparator<? super long[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public LongArrayAssert usingElementComparator(Comparator<? super Long> customComparator) {
     this.arrays = new LongArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public LongArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  /** {@inheritDoc} */
+  public LongArrayAssert usingDefaultElementComparator() {
     this.arrays = LongArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/LongArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/LongArrayAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> implements
     EnumerableAssert<LongArrayAssert>, ArraySortedAssert<LongArrayAssert, Long> {
@@ -201,13 +202,13 @@ public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> imp
   }
 
   /** {@inheritDoc} */
-  public LongArrayAssert isSortedAccordingTo(Comparator<? extends Long> comparator) {
+  public LongArrayAssert isSortedAccordingTo(Comparator<? super Long> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public LongArrayAssert usingComparator(Comparator<?> customComparator) {
+  public LongArrayAssert usingComparator(Comparator<? super long[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new LongArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/LongAssert.java
+++ b/src/main/java/org/fest/assertions/api/LongAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Ansgar Konermann
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class LongAssert extends AbstractComparableAssert<LongAssert, Long> implements NumberAssert<Long> {
 
@@ -139,7 +140,7 @@ public class LongAssert extends AbstractComparableAssert<LongAssert, Long> imple
   }
 
   @Override
-  public LongAssert usingComparator(Comparator<?> customComparator) {
+  public LongAssert usingComparator(Comparator<? super Long> customComparator) {
     super.usingComparator(customComparator);
     this.longs = new Longs(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/MapAssert.java
+++ b/src/main/java/org/fest/assertions/api/MapAssert.java
@@ -14,6 +14,7 @@
  */
 package org.fest.assertions.api;
 
+import java.util.Comparator;
 import java.util.Map;
 
 import org.fest.assertions.core.EnumerableAssert;
@@ -30,8 +31,9 @@ import org.fest.util.VisibleForTesting;
  * @author David DIDIER
  * @author Yvonne Wang
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
-public class MapAssert extends AbstractAssert<MapAssert, Map<?, ?>> implements EnumerableAssert<MapAssert> {
+public class MapAssert extends AbstractAssert<MapAssert, Map<?, ?>> implements EnumerableAssert<MapAssert, MapEntry> {
 
   @VisibleForTesting Maps maps = Maps.instance();
 
@@ -88,5 +90,15 @@ public class MapAssert extends AbstractAssert<MapAssert, Map<?, ?>> implements E
   public MapAssert doesNotContain(MapEntry...entries) {
     maps.assertDoesNotContain(info, actual, entries);
     return this;
+  }
+
+  /** {@inheritDoc} */
+  public MapAssert usingElementComparator(Comparator<? super MapEntry> customComparator) {
+    throw new UnsupportedOperationException("custom element Comparator is not supported for MapEntry comparison");
+  }
+
+  /** {@inheritDoc} */
+  public MapAssert usingDefaultElementComparator() {
+    throw new UnsupportedOperationException("custom element Comparator is not supported for MapEntry comparison");
   }
 }

--- a/src/main/java/org/fest/assertions/api/ObjectArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ObjectArrayAssert.java
@@ -35,9 +35,10 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert extends AbstractAssert<ObjectArrayAssert, Object[]> implements
-    ObjectEnumerableAssert<ObjectArrayAssert>, IndexedObjectEnumerableAssert, ArraySortedAssert<ObjectArrayAssert, Object> {
+    ObjectEnumerableAssert<ObjectArrayAssert, Object>, IndexedObjectEnumerableAssert<Object>, ArraySortedAssert<ObjectArrayAssert, Object> {
 
   @VisibleForTesting
   ObjectArrays arrays = ObjectArrays.instance();
@@ -249,13 +250,13 @@ public class ObjectArrayAssert extends AbstractAssert<ObjectArrayAssert, Object[
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert isSortedAccordingTo(Comparator<? extends Object> comparator) {
+  public ObjectArrayAssert isSortedAccordingTo(Comparator<? super Object> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public ObjectArrayAssert usingComparator(Comparator<?> customComparator) {
+  public ObjectArrayAssert usingComparator(Comparator<? super Object[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new ObjectArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/ObjectArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ObjectArrayAssert.java
@@ -37,13 +37,13 @@ import org.fest.util.VisibleForTesting;
  * @author Nicolas François
  * @author Mikhail Mazursky
  */
-public class ObjectArrayAssert extends AbstractAssert<ObjectArrayAssert, Object[]> implements
-    ObjectEnumerableAssert<ObjectArrayAssert, Object>, IndexedObjectEnumerableAssert<Object>, ArraySortedAssert<ObjectArrayAssert, Object> {
+public class ObjectArrayAssert<T> extends AbstractAssert<ObjectArrayAssert<T>, T[]> implements
+    ObjectEnumerableAssert<ObjectArrayAssert<T>, T>, IndexedObjectEnumerableAssert<T>, ArraySortedAssert<ObjectArrayAssert<T>, T> {
 
   @VisibleForTesting
   ObjectArrays arrays = ObjectArrays.instance();
 
-  protected ObjectArrayAssert(Object[] actual) {
+  protected ObjectArrayAssert(T[] actual) {
     super(actual, ObjectArrayAssert.class);
   }
 
@@ -58,217 +58,211 @@ public class ObjectArrayAssert extends AbstractAssert<ObjectArrayAssert, Object[
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert isNotEmpty() {
+  public ObjectArrayAssert<T> isNotEmpty() {
     arrays.assertNotEmpty(info, actual);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert hasSize(int expected) {
+  public ObjectArrayAssert<T> hasSize(int expected) {
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
   
   /** {@inheritDoc} */
-  public ObjectArrayAssert hasSameSizeAs(Object[] other) {
+  public ObjectArrayAssert<T> hasSameSizeAs(Object[] other) {
     arrays.assertHasSameSizeAs(info, actual, other);
     return this;
   }
   
   /** {@inheritDoc} */
-  public ObjectArrayAssert hasSameSizeAs(Iterable<?> other) {
+  public ObjectArrayAssert<T> hasSameSizeAs(Iterable<?> other) {
     arrays.assertHasSameSizeAs(info, actual, other);
     return this;
   }  
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert contains(Object... values) {
+  public ObjectArrayAssert<T> contains(Object... values) {
     arrays.assertContains(info, actual, values);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert containsOnly(Object... values) {
+  public ObjectArrayAssert<T> containsOnly(Object... values) {
     arrays.assertContainsOnly(info, actual, values);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert containsSequence(Object... sequence) {
+  public ObjectArrayAssert<T> containsSequence(Object... sequence) {
     arrays.assertContainsSequence(info, actual, sequence);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert contains(Object value, Index index) {
+  public ObjectArrayAssert<T> contains(Object value, Index index) {
     arrays.assertContains(info, actual, value, index);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert doesNotContain(Object value, Index index) {
+  public ObjectArrayAssert<T> doesNotContain(Object value, Index index) {
     arrays.assertDoesNotContain(info, actual, value, index);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert doesNotContain(Object... values) {
+  public ObjectArrayAssert<T> doesNotContain(Object... values) {
     arrays.assertDoesNotContain(info, actual, values);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert doesNotHaveDuplicates() {
+  public ObjectArrayAssert<T> doesNotHaveDuplicates() {
     arrays.assertDoesNotHaveDuplicates(info, actual);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert startsWith(Object... sequence) {
+  public ObjectArrayAssert<T> startsWith(Object... sequence) {
     arrays.assertStartsWith(info, actual, sequence);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert endsWith(Object... sequence) {
+  public ObjectArrayAssert<T> endsWith(Object... sequence) {
     arrays.assertEndsWith(info, actual, sequence);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert containsNull() {
+  public ObjectArrayAssert<T> containsNull() {
     arrays.assertContainsNull(info, actual);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert doesNotContainNull() {
+  public ObjectArrayAssert<T> doesNotContainNull() {
     arrays.assertDoesNotContainNull(info, actual);
     return this;
   }
 
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert are(Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> are(Condition<E> condition) {
 	  arrays.assertAre(info, actual, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areNot(Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areNot(Condition<E> condition) {
 	  arrays.assertAreNot(info, actual, condition);
 	  return myself;
   } 
  
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert have(Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> have(Condition<E> condition) {
 	  arrays.assertHave(info, actual, condition);
 	  return myself;
   }  
 
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert doNotHave(Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> doNotHave(Condition<E> condition) {
 	  arrays.assertDoNotHave(info, actual, condition);
 	  return myself;
   }   
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areAtLeast(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areAtLeast(int times, Condition<E> condition) {
 	  arrays.assertAreAtLeast(info, actual, times, condition);
 	  return myself;
   }   
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areNotAtLeast(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areNotAtLeast(int times, Condition<E> condition) {
 	  arrays.assertAreNotAtLeast(info, actual, times, condition);
 	  return myself;
   }     
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areAtMost(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areAtMost(int times, Condition<E> condition) {
 	  arrays.assertAreAtMost(info, actual, times, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areNotAtMost(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areNotAtMost(int times, Condition<E> condition) {
 	  arrays.assertAreNotAtMost(info, actual, times, condition);
 	  return myself;
   }     
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areExactly(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areExactly(int times, Condition<E> condition) {
 	  arrays.assertAreExactly(info, actual, times, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert areNotExactly(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> areNotExactly(int times, Condition<E> condition) {
 	  arrays.assertAreNotExactly(info, actual, times, condition);
 	  return myself;
   }  
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert haveAtLeast(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> haveAtLeast(int times, Condition<E> condition) {
 	  arrays.assertHaveAtLeast(info, actual, times, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert doNotHaveAtLeast(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> doNotHaveAtLeast(int times, Condition<E> condition) {
 	  arrays.assertDoNotHaveAtLeast(info, actual, times, condition);
 	  return myself;
   }  
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert haveAtMost(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> haveAtMost(int times, Condition<E> condition) {
 	  arrays.assertHaveAtMost(info, actual, times, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert doNotHaveAtMost(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> doNotHaveAtMost(int times, Condition<E> condition) {
 	  arrays.assertDoNotHaveAtMost(info, actual, times, condition);
 	  return myself;
   }  
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert haveExactly(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> haveExactly(int times, Condition<E> condition) {
 	  arrays.assertHaveExactly(info, actual, times, condition);
 	  return myself;
   }
   
   /** {@inheritDoc} */
-  public <E> ObjectArrayAssert doNotHaveExactly(int times, Condition<E> condition) {
+  public <E> ObjectArrayAssert<T> doNotHaveExactly(int times, Condition<E> condition) {
 	  arrays.assertDoNotHaveExactly(info, actual, times, condition);
 	  return myself;
   }  
   
   /** {@inheritDoc} */
-  public ObjectArrayAssert isSorted() {
+  public ObjectArrayAssert<T> isSorted() {
     arrays.assertIsSorted(info, actual);
     return this;
   }
 
   /** {@inheritDoc} */
-  public ObjectArrayAssert isSortedAccordingTo(Comparator<? super Object> comparator) {
+  public ObjectArrayAssert<T> isSortedAccordingTo(Comparator<? super T> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
-  @Override
-  public ObjectArrayAssert usingComparator(Comparator<? super Object[]> customComparator) {
-    super.usingComparator(customComparator);
+  public ObjectArrayAssert<T> usingElementComparator(Comparator<? super T> customComparator) {
     this.arrays = new ObjectArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
-  @Override
-  public ObjectArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+
+  public ObjectArrayAssert<T> usingDefaultElementComparator() {
     this.arrays = ObjectArrays.instance();
     return myself;
   }
-  
-  
-  
+
 }

--- a/src/main/java/org/fest/assertions/api/ObjectAssert.java
+++ b/src/main/java/org/fest/assertions/api/ObjectAssert.java
@@ -25,10 +25,11 @@ import org.fest.util.IntrospectionError;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
-public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
+public class ObjectAssert<T> extends AbstractAssert<ObjectAssert<T>, T> {
 
-  protected ObjectAssert(Object actual) {
+  protected ObjectAssert(T actual) {
     super(actual, ObjectAssert.class);
   }
 
@@ -40,7 +41,7 @@ public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
    * @throws AssertionError if the actual {@code Object} is {@code null}.
    * @throws AssertionError if the actual {@code Object} is not an instance of the given type.
    */
-  public ObjectAssert isInstanceOf(Class<?> type) {
+  public ObjectAssert<T> isInstanceOf(Class<?> type) {
     objects.assertIsInstanceOf(info, actual, type);
     return this;
   }
@@ -54,7 +55,7 @@ public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
    * @throws NullPointerException if the given array of types is {@code null}.
    * @throws NullPointerException if the given array of types contains {@code null}s.
    */
-  public ObjectAssert isInstanceOfAny(Class<?>... types) {
+  public ObjectAssert<T> isInstanceOfAny(Class<?>... types) {
     objects.assertIsInstanceOfAny(info, actual, types);
     return this;
   }
@@ -86,7 +87,7 @@ public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
    * @throws AssertionError if the actual and the given object are not lenient equals.
    * @throws AssertionError if the other object is not an instance of the actual type.
    */
-  public ObjectAssert isLenientEqualsToByIgnoringNullFields(Object other) {
+  public ObjectAssert<T> isLenientEqualsToByIgnoringNullFields(T other) {
     objects.assertIsLenientEqualsToByIgnoringNullFields(info, actual, other);
     return this;
   }
@@ -117,7 +118,7 @@ public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
    * @throws AssertionError if the other object is not an instance of the actual type.
    * @throws IntrospectionError if a field does not exist in actual.
    */
-  public ObjectAssert isLenientEqualsToByAcceptingFields(Object other, String... fields) {
+  public ObjectAssert<T> isLenientEqualsToByAcceptingFields(T other, String... fields) {
     objects.assertIsLenientEqualsToByAcceptingFields(info, actual, other, fields);
     return this;
   }
@@ -147,7 +148,7 @@ public class ObjectAssert extends AbstractAssert<ObjectAssert, Object> {
    * @throws AssertionError if the actual and the given object are not lenient equals.
    * @throws AssertionError if the other object is not an instance of the actual type.
    */
-  public ObjectAssert isLenientEqualsToByIgnoringFields(Object other, String... fields) {
+  public ObjectAssert<T> isLenientEqualsToByIgnoringFields(T other, String... fields) {
     objects.assertIsLenientEqualsToByIgnoringFields(info, actual, other, fields);
     return this;
   }

--- a/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> implements
     EnumerableAssert<ShortArrayAssert>, ArraySortedAssert<ShortArrayAssert, Short> {
@@ -201,13 +202,13 @@ public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> 
   }
 
   /** {@inheritDoc} */
-  public ShortArrayAssert isSortedAccordingTo(Comparator<? extends Short> comparator) {
+  public ShortArrayAssert isSortedAccordingTo(Comparator<? super Short> comparator) {
     arrays.assertIsSortedAccordingToComparator(info, actual, comparator);
     return this;
   }
 
   @Override
-  public ShortArrayAssert usingComparator(Comparator<?> customComparator) {
+  public ShortArrayAssert usingComparator(Comparator<? super short[]> customComparator) {
     super.usingComparator(customComparator);
     this.arrays = new ShortArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
@@ -35,7 +35,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  */
 public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> implements
-    EnumerableAssert<ShortArrayAssert>, ArraySortedAssert<ShortArrayAssert, Short> {
+    EnumerableAssert<ShortArrayAssert, Short>, ArraySortedAssert<ShortArrayAssert, Short> {
 
   @VisibleForTesting
   ShortArrays arrays = ShortArrays.instance();
@@ -207,16 +207,14 @@ public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> 
     return this;
   }
 
-  @Override
-  public ShortArrayAssert usingComparator(Comparator<? super short[]> customComparator) {
-    super.usingComparator(customComparator);
+  /** {@inheritDoc} */
+  public ShortArrayAssert usingElementComparator(Comparator<? super Short> customComparator) {
     this.arrays = new ShortArrays(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
 
-  @Override
-  public ShortArrayAssert usingDefaultComparator() {
-    super.usingDefaultComparator();
+  /** {@inheritDoc} */
+  public ShortArrayAssert usingDefaultElementComparator() {
     this.arrays = ShortArrays.instance();
     return myself;
   }

--- a/src/main/java/org/fest/assertions/api/ShortAssert.java
+++ b/src/main/java/org/fest/assertions/api/ShortAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author David DIDIER
  * @author Ansgar Konermann
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ShortAssert extends AbstractComparableAssert<ShortAssert, Short> implements NumberAssert<Short> {
 
@@ -138,7 +139,7 @@ public class ShortAssert extends AbstractComparableAssert<ShortAssert, Short> im
   }
 
   @Override
-  public ShortAssert usingComparator(Comparator<?> customComparator) {
+  public ShortAssert usingComparator(Comparator<? super Short> customComparator) {
     super.usingComparator(customComparator);
     this.shorts = new Shorts(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/StringAssert.java
+++ b/src/main/java/org/fest/assertions/api/StringAssert.java
@@ -35,7 +35,7 @@ import org.fest.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  */
-public class StringAssert extends AbstractAssert<StringAssert, String> implements EnumerableAssert<StringAssert> {
+public class StringAssert extends AbstractAssert<StringAssert, String> implements EnumerableAssert<StringAssert, String> {
 
   @VisibleForTesting Strings strings = Strings.instance();
 
@@ -194,13 +194,24 @@ public class StringAssert extends AbstractAssert<StringAssert, String> implement
     return this;
   }
 
+  /** {@inheritDoc} */
+  public StringAssert usingElementComparator(Comparator<? super String> customComparator) {
+    // TODO maybe use Comparator<? super Character>
+    throw new UnsupportedOperationException("custom element Comparator is not supported for String comparison");
+  }
+
+  /** {@inheritDoc} */
+  public StringAssert usingDefaultElementComparator() {
+    throw new UnsupportedOperationException("custom element Comparator is not supported for String comparison");
+  }
+
   @Override
   public StringAssert usingComparator(Comparator<? super String> customComparator) {
     super.usingComparator(customComparator);
     this.strings = new Strings(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;
   }
-  
+
   @Override
   public StringAssert usingDefaultComparator() {
     super.usingDefaultComparator();

--- a/src/main/java/org/fest/assertions/api/StringAssert.java
+++ b/src/main/java/org/fest/assertions/api/StringAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author David DIDIER
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class StringAssert extends AbstractAssert<StringAssert, String> implements EnumerableAssert<StringAssert> {
 
@@ -194,7 +195,7 @@ public class StringAssert extends AbstractAssert<StringAssert, String> implement
   }
 
   @Override
-  public StringAssert usingComparator(Comparator<?> customComparator) {
+  public StringAssert usingComparator(Comparator<? super String> customComparator) {
     super.usingComparator(customComparator);
     this.strings = new Strings(new ComparatorBasedComparisonStrategy(customComparator));
     return myself;

--- a/src/main/java/org/fest/assertions/api/filter/Filters.java
+++ b/src/main/java/org/fest/assertions/api/filter/Filters.java
@@ -57,6 +57,7 @@ import org.fest.util.VisibleForTesting;
  * @param <E> the type of element of group to filter.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class Filters<E> {
 
@@ -308,7 +309,8 @@ public class Filters<E> {
     checkPropertyNameToFilterOnIsNotNull();
     List<E> newFilteredIterable = new ArrayList<E>();
     for (E element : filteredIterable) {
-      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, element);
+      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, propertyValue
+          .getClass(), element);
       if (areEqual(propertyValueOfCurrentElement, propertyValue)) {
         newFilteredIterable.add(element);
       }
@@ -335,7 +337,8 @@ public class Filters<E> {
     checkPropertyNameToFilterOnIsNotNull();
     List<E> newFilteredIterable = new ArrayList<E>();
     for (E element : filteredIterable) {
-      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, element);
+      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, propertyValue
+          .getClass(), element);
       if (!areEqual(propertyValueOfCurrentElement, propertyValue)) {
         newFilteredIterable.add(element);
       }
@@ -367,7 +370,8 @@ public class Filters<E> {
     checkPropertyNameToFilterOnIsNotNull();
     List<E> newFilteredIterable = new ArrayList<E>();
     for (E element : filteredIterable) {
-      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, element);
+      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, propertyValues
+          .getClass().getComponentType(), element);
       if (isItemInArray(propertyValueOfCurrentElement, propertyValues)) {
         newFilteredIterable.add(element);
       }
@@ -394,7 +398,8 @@ public class Filters<E> {
     checkPropertyNameToFilterOnIsNotNull();
     List<E> newFilteredIterable = new ArrayList<E>();
     for (E element : filteredIterable) {
-      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, element);
+      Object propertyValueOfCurrentElement = propertySupport.propertyValueOf(propertyNameToFilterOn, propertyValues
+          .getClass().getComponentType(), element);
       if (!isItemInArray(propertyValueOfCurrentElement, propertyValues)) {
         newFilteredIterable.add(element);
       }

--- a/src/main/java/org/fest/assertions/core/ArraySortedAssert.java
+++ b/src/main/java/org/fest/assertions/core/ArraySortedAssert.java
@@ -17,7 +17,7 @@ package org.fest.assertions.core;
 import java.util.Comparator;
 
 /**
- * Assertions applicable to primitive arrays or arrays of elements wether naturally {@link Comparable} or according to a
+ * Assertions applicable to primitive arrays or arrays of elements either naturally {@link Comparable} or according to a
  * given {@link Comparator}.
  * <p>
  * Note that the contract defined here is can't be totally applied to List (that's why its name is not SortedAssert),
@@ -30,6 +30,7 @@ import java.util.Comparator;
  * @param <E> the array element type.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public interface ArraySortedAssert<S, E> {
 
@@ -69,8 +70,8 @@ public interface ArraySortedAssert<S, E> {
    * @throws AssertionError if the actual array is not sorted according to the given comparator.
    * @throws AssertionError if the actual array is <code>null</code>.
    * @throws NullPointerException if the given comparator is <code>null</code>.
-   * @throws AssertionError if the actual array elements are not mutually comparabe according to given Comparator.
+   * @throws AssertionError if the actual array elements are not mutually comparable according to given Comparator.
    */
-  S isSortedAccordingTo(Comparator<? extends E> comparator);
+  S isSortedAccordingTo(Comparator<? super E> comparator);
 
 }

--- a/src/main/java/org/fest/assertions/core/Assert.java
+++ b/src/main/java/org/fest/assertions/core/Assert.java
@@ -159,7 +159,7 @@ public interface Assert<S, A> extends Descriptable<S>, ExtensionPoints<S, A> {
    * @return {@code this} assertion object.
    */
   S usingDefaultComparator();
-  
+
   /**
    * Throws <code>{@link UnsupportedOperationException}</code> if called. It is easy to accidentally call
    * <code>{@link #equals(Object)}</code> instead of <code>isEqualTo</code>.

--- a/src/main/java/org/fest/assertions/core/Assert.java
+++ b/src/main/java/org/fest/assertions/core/Assert.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public interface Assert<S, A> extends Descriptable<S>, ExtensionPoints<S, A> {
 
@@ -149,7 +150,7 @@ public interface Assert<S, A> extends Descriptable<S>, ExtensionPoints<S, A> {
    * @throws NullPointerException if the given comparator is {@code null}.
    * @return {@code this} assertion object.
    */
-  S usingComparator(Comparator<?> customComparator);
+  S usingComparator(Comparator<? super A> customComparator);
 
   /**
    * Revert to standard comparison for incoming assertion checks.<br>

--- a/src/main/java/org/fest/assertions/core/EnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/EnumerableAssert.java
@@ -14,16 +14,19 @@
  */
 package org.fest.assertions.core;
 
+import java.util.Comparator;
+
 /**
  * Assertions applicable to groups of values that can be enumerated (e.g. arrays, collections or strings.)
  * @param <S> the "self" type of this assertion class. Please read
  * &quot;<a href="http://bit.ly/anMa4g" target="_blank">Emulating 'self types' using Java Generics to simplify fluent
  * API implementation</a>&quot; for more details.
- *
+ * @param <T> the type of elements of the "actual" value.
+ * 
  * @author Yvonne Wang
  * @author Alex Ruiz
  */
-public interface EnumerableAssert<S> {
+public interface EnumerableAssert<S, T> {
 
   /**
    * Verifies that the actual group of values is {@code null} or empty.
@@ -51,4 +54,8 @@ public interface EnumerableAssert<S> {
    * @throws AssertionError if the number of values of the actual group is not equal to the given one.
    */
   S hasSize(int expected);
+
+  S usingElementComparator(Comparator<? super T> customComparator);
+
+  S usingDefaultElementComparator();
 }

--- a/src/main/java/org/fest/assertions/core/IndexedObjectEnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/IndexedObjectEnumerableAssert.java
@@ -20,8 +20,9 @@ import org.fest.assertions.data.Index;
  * Assertions methods applicable to indexed groups of objects (e.g. arrays or lists.)
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
-public interface IndexedObjectEnumerableAssert {
+public interface IndexedObjectEnumerableAssert<T> {
 
   /**
    * Verifies that the actual group contains the given object at the given index.
@@ -34,7 +35,7 @@ public interface IndexedObjectEnumerableAssert {
    * the actual group.
    * @throws AssertionError if the actual group does not contain the given object at the given index.
    */
-  IndexedObjectEnumerableAssert contains(Object value, Index index);
+  IndexedObjectEnumerableAssert<T> contains(T value, Index index);
 
   /**
    * Verifies that the actual group does not contain the given object at the given index.
@@ -45,5 +46,5 @@ public interface IndexedObjectEnumerableAssert {
    * @throws NullPointerException if the given {@code Index} is {@code null}.
    * @throws AssertionError if the actual group contains the given object at the given index.
    */
-  IndexedObjectEnumerableAssert doesNotContain(Object value, Index index);
+  IndexedObjectEnumerableAssert<T> doesNotContain(T value, Index index);
 }

--- a/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
@@ -19,12 +19,14 @@ package org.fest.assertions.core;
  * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
  *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
+ * @param <T> the type of elements of the "actual" value.
  * 
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
-public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
+public interface ObjectEnumerableAssert<S, T> extends EnumerableAssert<S> {
 
   /**
    * Verifies that the actual group contains the given values, in any order.
@@ -35,7 +37,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not contain the given values.
    */
-  S contains(Object... values);
+  S contains(T... values);
 
   /**
    * Verifies that the actual group contains only the given values and nothing else, in any order.
@@ -47,7 +49,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group contains some
    *           or none of the given values, or the actual group contains more values than the given ones.
    */
-  S containsOnly(Object... values);
+  S containsOnly(T... values);
 
   /**
    * Verifies that the actual group contains the given sequence, without any other values between them.
@@ -57,7 +59,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the actual group does not contain the given sequence.
    */
-  S containsSequence(Object... sequence);
+  S containsSequence(T... sequence);
 
   /**
    * Verifies that the actual group does not contain the given values.
@@ -68,7 +70,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group contains any of the given values.
    */
-  S doesNotContain(Object... values);
+  S doesNotContain(T... values);
 
   /**
    * Verifies that the actual group does not contain duplicates.
@@ -89,7 +91,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not start with the given sequence of objects.
    */
-  S startsWith(Object... sequence);
+  S startsWith(T... sequence);
 
   /**
    * Verifies that the actual group ends with the given sequence of objects, without any other objects between them.
@@ -102,7 +104,7 @@ public interface ObjectEnumerableAssert<S> extends EnumerableAssert<S> {
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not end with the given sequence of objects.
    */
-  S endsWith(Object... sequence);
+  S endsWith(T... sequence);
 
   /**
    * Verifies that the actual group contains at least a null element.

--- a/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
@@ -14,6 +14,7 @@
  */
 package org.fest.assertions.core;
 
+
 /**
  * Assertions methods applicable to groups of objects (e.g. arrays or collections.)
  * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
@@ -26,7 +27,7 @@ package org.fest.assertions.core;
  * @author Nicolas François
  * @author Mikhail Mazursky
  */
-public interface ObjectEnumerableAssert<S, T> extends EnumerableAssert<S> {
+public interface ObjectEnumerableAssert<S, T> extends EnumerableAssert<S, T> {
 
   /**
    * Verifies that the actual group contains the given values, in any order.
@@ -280,5 +281,4 @@ public interface ObjectEnumerableAssert<S, T> extends EnumerableAssert<S> {
    * This method is an alias {@link #areNotExactly(int, Condition)}.
    */
   <E> S doNotHaveExactly(int n, Condition<E> condition);
-
 }

--- a/src/main/java/org/fest/assertions/groups/Properties.java
+++ b/src/main/java/org/fest/assertions/groups/Properties.java
@@ -27,10 +27,12 @@ import org.fest.util.VisibleForTesting;
  * Extracts the values of a specified property from the elements of a given <code>{@link Collection}</code> or array.
  *
  * @author Yvonne Wang
+ * @author Mikhail Mazursky
  */
-public class Properties {
+public class Properties<T> {
 
   @VisibleForTesting final String propertyName;
+  final Class<T> propertyType;
 
   @VisibleForTesting PropertySupport propertySupport = PropertySupport.instance();
 
@@ -42,9 +44,9 @@ public class Properties {
    * @throws IllegalArgumentException if the given property name is empty.
    * @return the created {@code Properties}.
    */
-  public static Properties extractProperty(String propertyName) {
+  public static <T> Properties<T> extractProperty(String propertyName, Class<T> propertyType) {
     checkIsNotNullOrEmpty(propertyName);
-    return new Properties(propertyName);
+    return new Properties<T>(propertyName, propertyType);
   }
 
   private static void checkIsNotNullOrEmpty(String propertyName) {
@@ -53,8 +55,9 @@ public class Properties {
       throw new IllegalArgumentException("The name of the property to read should not be empty");
   }
 
-  @VisibleForTesting Properties(String propertyName) {
+  @VisibleForTesting Properties(String propertyName, Class<T> propertyType) {
     this.propertyName = propertyName;
+    this.propertyType = propertyType;
   }
 
   /**
@@ -65,8 +68,8 @@ public class Properties {
    * @throws IntrospectionError if an element in the given {@code Collection} does not have a property with a matching
    * name.
    */
-  public List<?> from(Collection<?> c) {
-    return propertySupport.propertyValues(propertyName, c);
+  public List<T> from(Collection<?> c) {
+    return propertySupport.propertyValues(propertyName, propertyType, c);
   }
 
   /**
@@ -76,7 +79,7 @@ public class Properties {
    * @return the values of the previously specified property extracted from the given array.
    * @throws IntrospectionError if an element in the given array does not have a property with a matching name.
    */
-  public List<?> from(Object[] array) {
-    return propertySupport.propertyValues(propertyName, wrap(array));
+  public List<T> from(Object[] array) {
+    return propertySupport.propertyValues(propertyName, propertyType, wrap(array));
   }
 }

--- a/src/main/java/org/fest/assertions/internal/BooleanArrays.java
+++ b/src/main/java/org/fest/assertions/internal/BooleanArrays.java
@@ -25,6 +25,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class BooleanArrays {
 
@@ -240,7 +241,7 @@ public class BooleanArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, boolean[] actual,
-      Comparator<? extends Boolean> comparator) {
+      Comparator<? super Boolean> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 

--- a/src/main/java/org/fest/assertions/internal/ByteArrays.java
+++ b/src/main/java/org/fest/assertions/internal/ByteArrays.java
@@ -27,6 +27,7 @@ import org.fest.util.VisibleForTesting;
  * Reusable assertions for arrays of {@code byte}s.
  * 
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ByteArrays {
 
@@ -253,7 +254,7 @@ public class ByteArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, byte[] actual,
-      Comparator<? extends Byte> comparator) {
+      Comparator<? super Byte> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 }

--- a/src/main/java/org/fest/assertions/internal/CharArrays.java
+++ b/src/main/java/org/fest/assertions/internal/CharArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class CharArrays {
 
@@ -254,7 +255,7 @@ public class CharArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, char[] actual,
-      Comparator<? extends Character> comparator) {
+      Comparator<? super Character> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 }

--- a/src/main/java/org/fest/assertions/internal/DoubleArrays.java
+++ b/src/main/java/org/fest/assertions/internal/DoubleArrays.java
@@ -27,6 +27,7 @@ import org.fest.util.VisibleForTesting;
  * Reusable assertions for arrays of {@code double}s.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class DoubleArrays {
 
@@ -251,7 +252,7 @@ public class DoubleArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, double[] actual,
-      Comparator<? extends Double> comparator) {
+      Comparator<? super Double> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 }

--- a/src/main/java/org/fest/assertions/internal/FloatArrays.java
+++ b/src/main/java/org/fest/assertions/internal/FloatArrays.java
@@ -27,6 +27,7 @@ import org.fest.util.VisibleForTesting;
  * Reusable assertions for arrays of {@code float}s.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class FloatArrays {
 
@@ -251,7 +252,7 @@ public class FloatArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, float[] actual,
-      Comparator<? extends Float> comparator) {
+      Comparator<? super Float> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 

--- a/src/main/java/org/fest/assertions/internal/IntArrays.java
+++ b/src/main/java/org/fest/assertions/internal/IntArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class IntArrays {
 
@@ -254,7 +255,7 @@ public class IntArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, int[] actual,
-      Comparator<? extends Integer> comparator) {
+      Comparator<? super Integer> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 

--- a/src/main/java/org/fest/assertions/internal/Lists.java
+++ b/src/main/java/org/fest/assertions/internal/Lists.java
@@ -184,13 +184,13 @@ public class Lists {
       if (actual.size() == 0) return;
       Comparator rawComparator = comparator;
       if (actual.size() == 1) {
-        // Compare unique element with itself to verify thta it is compatible with comparator (a ClassCastException is
+        // Compare unique element with itself to verify that it is compatible with comparator (a ClassCastException is
         // thrown if not). We have to use a raw comparator to compare the unique element of actual ... :(
         rawComparator.compare(actual.get(0), actual.get(0));
         return;
       }
       for (int i = 0; i < actual.size() - 1; i++) {
-        // List is sorted in comparator defined order iif current element is less or equal than next element
+        // List is sorted in comparator defined order if current element is less or equal than next element
         if (rawComparator.compare(actual.get(i), actual.get(i + 1)) > 0)
           throw failures.failure(info, shouldBeSortedAccordingToGivenComparator(i, actual, comparator));
       }

--- a/src/main/java/org/fest/assertions/internal/LongArrays.java
+++ b/src/main/java/org/fest/assertions/internal/LongArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  *
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class LongArrays {
 
@@ -252,7 +253,7 @@ public class LongArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, long[] actual,
-      Comparator<? extends Long> comparator) {
+      Comparator<? super Long> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 }

--- a/src/main/java/org/fest/assertions/internal/Objects.java
+++ b/src/main/java/org/fest/assertions/internal/Objects.java
@@ -47,6 +47,7 @@ import org.fest.util.VisibleForTesting;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class Objects {
 
@@ -76,7 +77,7 @@ public class Objects {
   public Objects(ComparisonStrategy comparisonStrategy) {
     this.comparisonStrategy = comparisonStrategy;
   }
-  
+
   @VisibleForTesting
   public Comparator<?> getComparator() {
     if (comparisonStrategy instanceof ComparatorBasedComparisonStrategy) {
@@ -275,7 +276,7 @@ public class Objects {
    * @throws IllegalArgumentException if the given collection is empty.
    * @throws AssertionError if the given object is not present in the given collection.
    */
-  public <A> void assertIsIn(AssertionInfo info, Object actual, Iterable<? extends A> values) {
+  public <A> void assertIsIn(AssertionInfo info, A actual, Iterable<? extends A> values) {
     checkIsNotNullAndNotEmpty(values);
     assertNotNull(info, actual);
     if (isActualIn(actual, values)) return;
@@ -291,7 +292,7 @@ public class Objects {
    * @throws IllegalArgumentException if the given collection is empty.
    * @throws AssertionError if the given object is present in the given collection.
    */
-  public <A> void assertIsNotIn(AssertionInfo info, Object actual, Iterable<? extends A> values) {
+  public <A> void assertIsNotIn(AssertionInfo info, A actual, Iterable<? extends A> values) {
     checkIsNotNullAndNotEmpty(values);
     assertNotNull(info, actual);
     if (!isActualIn(actual, values)) return;
@@ -303,8 +304,8 @@ public class Objects {
     if (!values.iterator().hasNext()) throw new IllegalArgumentException("The given iterable should not be empty");
   }
 
-  private <A> boolean isActualIn(Object actual, Iterable<? extends A> values) {
-    for (Object value : values)
+  private <A> boolean isActualIn(A actual, Iterable<? extends A> values) {
+    for (A value : values)
       if (areEqual(value, actual)) return true;
     return false;
   }
@@ -319,29 +320,29 @@ public class Objects {
    * @throws AssertionError if the actual and the given object are not lenient equals.
    * @throws AssertionError if the other object is not an instance of the actual type.
    */
-  public void assertIsLenientEqualsToByIgnoringNullFields(AssertionInfo info, Object actual, Object other){
-	assertIsInstanceOf(info, other, actual.getClass());
-	List<String> fieldsNames = new LinkedList<String>();
-	List<Object> values = new LinkedList<Object>();
-	List<String> nullFields = new LinkedList<String>();
-	for (Field field : actual.getClass().getDeclaredFields()) {
-		try {
-			Object otherFieldValue = propertySupport.propertyValue(field.getName(), other, field.getType());
-			if(otherFieldValue != null){
-				Object actualFieldValue = propertySupport.propertyValue(field.getName(), actual, field.getType());
-				if(!otherFieldValue.equals(actualFieldValue)){
-					fieldsNames.add(field.getName());
-					values.add(otherFieldValue);
-				}
-			} else {
-				nullFields.add(field.getName());
-			}
-		} catch (IntrospectionError e) {
-			// Not readeable field, skip.
-		}
-	}
-	if(fieldsNames.isEmpty()) return;
-	throw failures.failure(info, shouldBeLenientEqualByIgnoring (actual, fieldsNames, values, nullFields));	  
+  public <A> void assertIsLenientEqualsToByIgnoringNullFields(AssertionInfo info, A actual, A other){
+  	assertIsInstanceOf(info, other, actual.getClass());
+  	List<String> fieldsNames = new LinkedList<String>();
+  	List<Object> values = new LinkedList<Object>();
+  	List<String> nullFields = new LinkedList<String>();
+  	for (Field field : actual.getClass().getDeclaredFields()) {
+  		try {
+  			Object otherFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), other);
+  			if (otherFieldValue != null) {
+  				Object actualFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), actual);
+  				if (!otherFieldValue.equals(actualFieldValue)){
+  					fieldsNames.add(field.getName());
+  					values.add(otherFieldValue);
+  				}
+  			} else {
+  				nullFields.add(field.getName());
+  			}
+  		} catch (IntrospectionError e) {
+  			// Not readeable field, skip.
+  		}
+  	}
+  	if (fieldsNames.isEmpty()) return;
+  	throw failures.failure(info, shouldBeLenientEqualByIgnoring (actual, fieldsNames, values, nullFields));	  
   }
   
   /**
@@ -356,20 +357,20 @@ public class Objects {
    * @throws AssertionError if the other object is not an instance of the actual type.
    * @throws IntrospectionError if a field does not exist in actual.
    */
-  public void assertIsLenientEqualsToByAcceptingFields(AssertionInfo info, Object actual, Object other, String... fields){
-	assertIsInstanceOf(info, other, actual.getClass());
-	List<String> fieldsNames = new LinkedList<String>();
-	List<Object> values = new LinkedList<Object>();
-	for (String fieldName : fields) {
-		Object actualFieldValue = propertySupport.propertyValue(fieldName, actual, Object.class);
-		Object otherFieldValue = propertySupport.propertyValue(fieldName, other, Object.class);
-		if(!(actualFieldValue == otherFieldValue || (actualFieldValue != null && actualFieldValue.equals(otherFieldValue)))){
-			fieldsNames.add(fieldName);
-			values.add(otherFieldValue);				
-		}
-	}
-	if(fieldsNames.isEmpty()) return;
-	throw failures.failure(info, shouldBeLenientEqualByAccepting(actual, fieldsNames, values, list(fields)));	  
+  public <A> void assertIsLenientEqualsToByAcceptingFields(AssertionInfo info, A actual, A other, String... fields){
+  	assertIsInstanceOf(info, other, actual.getClass());
+  	List<String> fieldsNames = new LinkedList<String>();
+  	List<Object> values = new LinkedList<Object>();
+  	for (String fieldName : fields) {
+  		Object actualFieldValue = propertySupport.propertyValue(fieldName, Object.class, actual);
+  		Object otherFieldValue = propertySupport.propertyValue(fieldName, Object.class, other);
+  		if (!(actualFieldValue == otherFieldValue || (actualFieldValue != null && actualFieldValue.equals(otherFieldValue)))) {
+  			fieldsNames.add(fieldName);
+  			values.add(otherFieldValue);				
+  		}
+  	}
+  	if (fieldsNames.isEmpty()) return;
+  	throw failures.failure(info, shouldBeLenientEqualByAccepting(actual, fieldsNames, values, list(fields)));	  
   }
 
   /**
@@ -382,29 +383,29 @@ public class Objects {
    * @throws NullPointerException if the other type is {@code null}.
    * @throws AssertionError if the actual and the given object are not lenient equals.
    * @throws AssertionError if the other object is not an instance of the actual type.
-   */  
-	public void assertIsLenientEqualsToByIgnoringFields(AssertionInfo info, Object actual, Object other, String... fields) {
+   */
+	public <A> void assertIsLenientEqualsToByIgnoringFields(AssertionInfo info, A actual, A other, String... fields) {
 		assertIsInstanceOf(info, other, actual.getClass());
 		List<String> fieldsNames = new LinkedList<String>();
 		List<Object> values = new LinkedList<Object>();
 		Set<String> ignoredFields = set(fields);
 		for (Field field : actual.getClass().getDeclaredFields()) {
 			try {
-				if(!ignoredFields.contains(field.getName())){
-					Object otherFieldValue = propertySupport.propertyValue(field.getName(), other, field.getType());
-					if(otherFieldValue != null){
-						Object actualFieldValue = propertySupport.propertyValue(field.getName(), actual, field.getType());
-						if(!otherFieldValue.equals(actualFieldValue)){
+				if (!ignoredFields.contains(field.getName())) {
+					Object otherFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), other);
+					if (otherFieldValue != null) {
+						Object actualFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), actual);
+						if (!otherFieldValue.equals(actualFieldValue)) {
 							fieldsNames.add(field.getName());
 							values.add(otherFieldValue);
 						}
 					}
-				}	
+				}
 			} catch (IntrospectionError e) {
 				// Not readeable field, skip.
 			}
-		}		
-		if(fieldsNames.isEmpty()) return;
+		}
+		if (fieldsNames.isEmpty()) return;
 		throw failures.failure(info,shouldBeLenientEqualByIgnoring(actual, fieldsNames, values, list(fields)));	 		
-	}  
+	}
 }

--- a/src/main/java/org/fest/assertions/internal/ShortArrays.java
+++ b/src/main/java/org/fest/assertions/internal/ShortArrays.java
@@ -27,6 +27,7 @@ import org.fest.util.VisibleForTesting;
  * Reusable assertions for arrays of {@code short}s.
  * 
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ShortArrays {
 
@@ -253,7 +254,7 @@ public class ShortArrays {
    * @param comparator the {@link Comparator} used to compare array elements
    */
   public void assertIsSortedAccordingToComparator(AssertionInfo info, short[] actual,
-      Comparator<? extends Short> comparator) {
+      Comparator<? super Short> comparator) {
     Arrays.assertIsSortedAccordingToComparator(info, failures, actual, comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/AbstractTest_for_IterableAssert.java
+++ b/src/test/java/org/fest/assertions/api/AbstractTest_for_IterableAssert.java
@@ -17,23 +17,22 @@ package org.fest.assertions.api;
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Before;
-
 import org.fest.assertions.internal.Iterables;
+import org.junit.Before;
 
 /**
  * Tests for <code>{@link AbstractIterableAssert#contains(Object...)}</code>.
  *
  * @author Joel Costigliola
  */
-public class AbstractTest_for_IterableAssert {
+public abstract class AbstractTest_for_IterableAssert {
 
   protected Iterables iterables;
-  protected ConcreteIterableAssert assertions;
+  protected ConcreteIterableAssert<Object> assertions;
 
   @Before public void setUp() {
     iterables = mock(Iterables.class);
-    assertions = new ConcreteIterableAssert(emptyList());
+    assertions = new ConcreteIterableAssert<Object>(emptyList());
     assertions.iterables = iterables;
   }
 

--- a/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Iterable_Test.java
@@ -30,14 +30,14 @@ public class Assertions_assertThat_with_Iterable_Test {
 
   @Test
   public void should_create_Assert() {
-    IterableAssert assertions = Assertions.assertThat(set());
+    IterableAssert<Object> assertions = Assertions.assertThat(set());
     assertNotNull(assertions);
   }
 
   @Test
   public void should_pass_actual() {
     Iterable<String> names = set("Luke");
-    IterableAssert assertions = Assertions.assertThat(names);
+    IterableAssert<String> assertions = Assertions.assertThat(names);
     assertSame(names, assertions.actual);
   }
 }

--- a/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_List_Test.java
+++ b/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_List_Test.java
@@ -32,13 +32,13 @@ import org.junit.Test;
 public class Assertions_assertThat_with_List_Test {
 
   @Test public void should_create_Assert() {
-    IndexedObjectEnumerableAssert assertions = Assertions.assertThat(emptyList());
+    IndexedObjectEnumerableAssert<Object> assertions = Assertions.assertThat(emptyList());
     assertNotNull(assertions);
   }
 
   @Test public void should_pass_actual() {
     List<String> names = list("Luke");
-    ListAssert assertions = Assertions.assertThat(names);
+    ListAssert<String> assertions = Assertions.assertThat(names);
     assertSame(names, assertions.actual);
   }
 }

--- a/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_ObjectArray_Test.java
+++ b/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_ObjectArray_Test.java
@@ -23,17 +23,18 @@ import org.junit.Test;
  * Tests for <code>{@link Assertions#assertThat(Object[])}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class Assertions_assertThat_with_ObjectArray_Test {
 
   @Test public void should_create_Assert() {
-    ObjectArrayAssert assertions = Assertions.assertThat(emptyArray());
+    ObjectArrayAssert<Object> assertions = Assertions.assertThat(emptyArray());
     assertNotNull(assertions);
   }
 
   @Test public void should_pass_actual() {
     Object[] actual = emptyArray();
-    ObjectArrayAssert assertions = Assertions.assertThat(actual);
+    ObjectArrayAssert<Object> assertions = Assertions.assertThat(actual);
     assertSame(actual, assertions.actual);
   }
 }

--- a/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Object_Test.java
+++ b/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Object_Test.java
@@ -22,18 +22,19 @@ import org.junit.Test;
  * Tests for <code>{@link Assertions#assertThat(Object)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class Assertions_assertThat_with_Object_Test {
 
   @Test public void should_create_Assert() {
     Object actual = new Object();
-    ObjectAssert assertions = Assertions.assertThat(actual);
+    ObjectAssert<Object> assertions = Assertions.assertThat(actual);
     assertNotNull(assertions);
   }
 
   @Test public void should_pass_actual() {
     Object actual = new Object();
-    ObjectAssert assertions = Assertions.assertThat(actual);
+    ObjectAssert<Object> assertions = Assertions.assertThat(actual);
     assertSame(actual, assertions.actual);
   }
 }

--- a/src/test/java/org/fest/assertions/api/BigDecimalAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/BigDecimalAssert_usingComparator_Test.java
@@ -15,24 +15,36 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.math.BigDecimal;
+import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.BigDecimals;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link BigDecimalAssert#usingComparator(java.util.Comparator)}</code> and
  * <code>{@link BigDecimalAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class BigDecimalAssert_usingComparator_Test {
 
   private BigDecimalAssert assertions = new BigDecimalAssert(BigDecimal.ONE);
+
+  @Mock
+  private Comparator<BigDecimal> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void using_default_comparator_test() {
@@ -43,9 +55,9 @@ public class BigDecimalAssert_usingComparator_Test {
   
   @Test
   public void using_custom_comparator_test() {
-    // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.bigDecimals.getComparator(), CaseInsensitiveStringComparator.instance);
+    // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.bigDecimals.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/BooleanArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.BooleanArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.BooleanArrays;
 
@@ -33,9 +36,14 @@ import org.fest.assertions.internal.BooleanArrays;
  */
 public class BooleanArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Boolean> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Boolean> comparator;
 
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+  
   @Test
   public void should_verify_that_assertIsSorted_is_called() {
     BooleanArrays arrays = mock(BooleanArrays.class);

--- a/src/test/java/org/fest/assertions/api/BooleanArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanArrayAssert_usingComparator_Test.java
@@ -16,16 +16,20 @@ package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
 
+import java.util.Comparator;
+
 import static org.fest.assertions.test.BooleanArrayFactory.emptyArray;
 import static org.fest.assertions.test.ExpectedException.none;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.BooleanArrays;
 import org.fest.assertions.internal.Objects;
 import org.fest.assertions.test.ExpectedException;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link BooleanArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -37,8 +41,16 @@ public class BooleanArrayAssert_usingComparator_Test {
 
   @Rule
   public ExpectedException thrown = none();
-  
+
   private BooleanArrayAssert assertions = new BooleanArrayAssert(emptyArray());
+
+  @Mock
+  private Comparator<boolean[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void using_default_comparator_test() {
@@ -46,12 +58,12 @@ public class BooleanArrayAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, BooleanArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     thrown.expect(UnsupportedOperationException.class);
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
   }
   
 }

--- a/src/test/java/org/fest/assertions/api/BooleanArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanArrayAssert_usingComparator_Test.java
@@ -36,6 +36,7 @@ import org.fest.assertions.test.ExpectedException;
  * <code>{@link BooleanArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class BooleanArrayAssert_usingComparator_Test {
 
@@ -44,6 +45,8 @@ public class BooleanArrayAssert_usingComparator_Test {
 
   private BooleanArrayAssert assertions = new BooleanArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<Boolean> elementComparator;
   @Mock
   private Comparator<boolean[]> comparator;
 
@@ -61,9 +64,16 @@ public class BooleanArrayAssert_usingComparator_Test {
 
   @Test
   public void using_custom_comparator_test() {
-    thrown.expect(UnsupportedOperationException.class);
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
     assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays, BooleanArrays.instance());
   }
-  
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    thrown.expect(UnsupportedOperationException.class);
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+  }
 }

--- a/src/test/java/org/fest/assertions/api/BooleanAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanAssert_usingComparator_Test.java
@@ -16,14 +16,18 @@ package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
 
-import static org.fest.assertions.test.ExpectedException.none;
+import java.util.Comparator;
 
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.Objects;
 import org.fest.assertions.test.ExpectedException;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link BooleanAssert#usingComparator(java.util.Comparator)}</code> and
@@ -38,6 +42,14 @@ public class BooleanAssert_usingComparator_Test {
   
   private BooleanAssert assertions = new BooleanAssert(true);
 
+  @Mock
+  private Comparator<Boolean> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -48,7 +60,7 @@ public class BooleanAssert_usingComparator_Test {
   public void using_custom_comparator_test() {
     thrown.expect(UnsupportedOperationException.class);
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
   }
   
 }

--- a/src/test/java/org/fest/assertions/api/ByteArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.ByteArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.ByteArrays;
 
@@ -33,8 +36,13 @@ import org.fest.assertions.internal.ByteArrays;
  */
 public class ByteArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Byte> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Byte> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/ByteArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.ByteArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.ByteArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ByteArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class ByteArrayAssert_usingComparator_Test {
 
   private ByteArrayAssert assertions = new ByteArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<byte[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class ByteArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ByteArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link ByteArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ByteArrayAssert_usingComparator_Test {
 
-  private ByteArrayAssert assertions = new ByteArrayAssert(emptyArray());
+  private ByteArrayAssert assertions;
 
+  @Mock
+  private Comparator<Byte> elementComparator;
   @Mock
   private Comparator<byte[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new ByteArrayAssert(emptyArray());
   }
 
   @Test
@@ -50,12 +54,20 @@ public class ByteArrayAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, ByteArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, ByteArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ByteAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Bytes;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ByteAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class ByteAssert_usingComparator_Test {
 
   private ByteAssert assertions = new ByteAssert((byte)5);
 
+  @Mock
+  private Comparator<Byte> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class ByteAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.bytes.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.bytes.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/CharArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.CharArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.CharArrays;
 
@@ -33,8 +36,13 @@ import org.fest.assertions.internal.CharArrays;
  */
 public class CharArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Character> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Character> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/CharArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.CharArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.CharArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link CharArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class CharArrayAssert_usingComparator_Test {
 
   private CharArrayAssert assertions = new CharArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<char[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class CharArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/CharArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link CharArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class CharArrayAssert_usingComparator_Test {
 
-  private CharArrayAssert assertions = new CharArrayAssert(emptyArray());
+  private CharArrayAssert assertions;
 
+  @Mock
+  private Comparator<Character> elementComparator;
   @Mock
   private Comparator<char[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new CharArrayAssert(emptyArray());
   }
 
   @Test
@@ -56,6 +60,14 @@ public class CharArrayAssert_usingComparator_Test {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, CharArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/CharacterAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharacterAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Characters;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link CharacterAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class CharacterAssert_usingComparator_Test {
 
   private CharacterAssert assertions = new CharacterAssert('a');
 
+  @Mock
+  private Comparator<Character> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class CharacterAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.characters.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.characters.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/CollectionAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/CollectionAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Bytes;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ByteAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class CollectionAssert_usingComparator_Test {
 
   private ByteAssert assertions = new ByteAssert((byte)5);
 
+  @Mock
+  private Comparator<Byte> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class CollectionAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.bytes.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.bytes.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ConcreteIterableAssert.java
+++ b/src/test/java/org/fest/assertions/api/ConcreteIterableAssert.java
@@ -18,10 +18,11 @@ import java.util.Collection;
 
 /**
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
-public class ConcreteIterableAssert extends AbstractIterableAssert<ConcreteIterableAssert, Collection<?>> {
+public class ConcreteIterableAssert<T> extends AbstractIterableAssert<ConcreteIterableAssert<T>, Collection<T>, T> {
 
-  public ConcreteIterableAssert(Collection<?> actual) {
+  public ConcreteIterableAssert(Collection<T> actual) {
     super(actual, ConcreteIterableAssert.class);
   }
 }

--- a/src/test/java/org/fest/assertions/api/DateAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/DateAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Comparator;
 import java.util.Date;
-
-import org.junit.Test;
 
 import org.fest.assertions.internal.Dates;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link DateAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class DateAssert_usingComparator_Test {
 
   private DateAssert assertions = new DateAssert(new Date());
 
+  @Mock
+  private Comparator<Date> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class DateAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.dates.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.dates.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/DoubleArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleArrayAssert_isSortedAccordingToComparator_Test.java
@@ -15,16 +15,17 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.DoubleArrayFactory.emptyArray;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
-import org.junit.Test;
-
 import org.fest.assertions.internal.DoubleArrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link DoubleArrayAssert#isSortedAccordingTo(Comparator)}</code>.
@@ -33,8 +34,13 @@ import org.fest.assertions.internal.DoubleArrays;
  */
 public class DoubleArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Double> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Double> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/DoubleArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link DoubleArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class DoubleArrayAssert_usingComparator_Test {
 
-  private DoubleArrayAssert assertions = new DoubleArrayAssert(emptyArray());
+  private DoubleArrayAssert assertions;
 
+  @Mock
+  private Comparator<Double> elementComparator;
   @Mock
   private Comparator<double[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new DoubleArrayAssert(emptyArray());
   }
 
   @Test
@@ -56,6 +60,14 @@ public class DoubleArrayAssert_usingComparator_Test {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, DoubleArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/DoubleArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.DoubleArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.DoubleArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link DoubleArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class DoubleArrayAssert_usingComparator_Test {
 
   private DoubleArrayAssert assertions = new DoubleArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<double[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class DoubleArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/DoubleAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleAssert_usingComparator_Test.java
@@ -15,22 +15,35 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Comparator;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.Doubles;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link DoubleAssert#usingComparator(java.util.Comparator)}</code> and
  * <code>{@link DoubleAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class DoubleAssert_usingComparator_Test {
 
   private DoubleAssert assertions = new DoubleAssert(5.0);
+
+  @Mock
+  private Comparator<Double> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void using_default_comparator_test() {
@@ -38,12 +51,12 @@ public class DoubleAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.doubles, Doubles.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.doubles.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.doubles.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/FloatArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.FloatArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.FloatArrays;
 
@@ -33,8 +36,13 @@ import org.fest.assertions.internal.FloatArrays;
  */
 public class FloatArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Float> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Float> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/FloatArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatArrayAssert_usingComparator_Test.java
@@ -33,17 +33,21 @@ import org.fest.assertions.internal.Objects;
  * <code>{@link FloatArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class FloatArrayAssert_usingComparator_Test {
 
-  private FloatArrayAssert assertions = new FloatArrayAssert(emptyArray());
+  private FloatArrayAssert assertions;
 
+  @Mock
+  private Comparator<Float> elementComparator;
   @Mock
   private Comparator<float[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new FloatArrayAssert(emptyArray());
   }
 
   @Test
@@ -58,6 +62,14 @@ public class FloatArrayAssert_usingComparator_Test {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, FloatArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/FloatArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatArrayAssert_usingComparator_Test.java
@@ -16,13 +16,17 @@ package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
 
-import static org.fest.assertions.test.FloatArrayFactory.emptyArray;
+import java.util.Comparator;
 
+import static org.fest.assertions.test.FloatArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.FloatArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link FloatArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,18 +38,26 @@ public class FloatArrayAssert_usingComparator_Test {
 
   private FloatArrayAssert assertions = new FloatArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<float[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, FloatArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/FloatAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatAssert_usingComparator_Test.java
@@ -15,12 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Comparator;
+
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.Floats;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
 
 /**
  * Tests for <code>{@link FloatAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +36,14 @@ public class FloatAssert_usingComparator_Test {
 
   private FloatAssert assertions = new FloatAssert(5f);
 
+  @Mock
+  private Comparator<Float> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +54,8 @@ public class FloatAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.floats.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.floats.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IIterableAssert_areNotAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/IIterableAssert_areNotAtMost_Test.java
@@ -44,7 +44,7 @@ public class IIterableAssert_areNotAtMost_Test extends AbstractTest_for_Iterable
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.haveAtMost(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.haveAtMost(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/ImageAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ImageAssert_usingComparator_Test.java
@@ -15,17 +15,18 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.ExpectedException.none;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.awt.image.BufferedImage;
-
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Objects;
 import org.fest.assertions.test.ExpectedException;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ImageAssert#usingComparator(java.util.Comparator)}</code> and
@@ -40,6 +41,14 @@ public class ImageAssert_usingComparator_Test {
   
   private ImageAssert assertions = new ImageAssert(new BufferedImage(10, 10, 1));
 
+  @Mock
+  private Comparator<BufferedImage> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -50,7 +59,7 @@ public class ImageAssert_usingComparator_Test {
   public void using_custom_comparator_test() {
     thrown.expect(UnsupportedOperationException.class);
     // in that, we don't care of the comparator, the point to check is that we can't use a comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
   }
   
 }

--- a/src/test/java/org/fest/assertions/api/IntArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntArrayAssert_isSortedAccordingToComparator_Test.java
@@ -15,16 +15,17 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.IntArrayFactory.emptyArray;
-
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
-import org.junit.Test;
-
 import org.fest.assertions.internal.IntArrays;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link IntArrayAssert#isSortedAccordingTo(Comparator)}</code>.
@@ -33,8 +34,13 @@ import org.fest.assertions.internal.IntArrays;
  */
 public class IntArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Integer> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Integer> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/IntArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link IntArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class IntArrayAssert_usingComparator_Test {
 
-  private IntArrayAssert assertions = new IntArrayAssert(emptyArray());
+  private IntArrayAssert assertions;
 
+  @Mock
+  private Comparator<Integer> elementComparator;
   @Mock
   private Comparator<int[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new IntArrayAssert(emptyArray());
   }
 
   @Test
@@ -50,12 +54,20 @@ public class IntArrayAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, IntArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, IntArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IntArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.IntArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.IntArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link IntArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class IntArrayAssert_usingComparator_Test {
 
   private IntArrayAssert assertions = new IntArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<int[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class IntArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IntegerAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntegerAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Integers;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link IntegerAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class IntegerAssert_usingComparator_Test {
 
   private IntegerAssert assertions = new IntegerAssert(5);
 
+  @Mock
+  private Comparator<Integer> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class IntegerAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.integers.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.integers.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areAtLeast_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areAtLeast_Test extends AbstractTest_for_IterableAss
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areAtLeast(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areAtLeast(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areAtMost_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areAtMost_Test extends AbstractTest_for_IterableAsse
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areAtMost(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areAtMost(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areExactly_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areExactly_Test extends AbstractTest_for_IterableAss
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areExactly(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areExactly(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areNotAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areNotAtLeast_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areNotAtLeast_Test extends AbstractTest_for_Iterable
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areNotAtLeast(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areNotAtLeast(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areNotAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areNotAtMost_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areNotAtMost_Test extends AbstractTest_for_IterableA
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areNotAtMost(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areNotAtMost(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areNotExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areNotExactly_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areNotExactly_Test extends AbstractTest_for_Iterable
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areNotExactly(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areNotExactly(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_areNot_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_areNot_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_areNot_Test extends AbstractTest_for_IterableAssert 
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areNot(condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areNot(condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_are_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_are_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_are_Test extends AbstractTest_for_IterableAssert {
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.are(condition);
+	    ConcreteIterableAssert<Object> returned = assertions.are(condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_containsNull_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_containsNull_Test.java
@@ -34,7 +34,7 @@ public class IterableAssert_containsNull_Test extends AbstractTest_for_IterableA
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.containsNull();
+    ConcreteIterableAssert<Object> returned = assertions.containsNull();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_containsOnly_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_containsOnly_Test.java
@@ -36,7 +36,7 @@ public class IterableAssert_containsOnly_Test extends AbstractTest_for_IterableA
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.containsOnly("Luke");
+    ConcreteIterableAssert<Object> returned = assertions.containsOnly("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_containsSequence_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_containsSequence_Test.java
@@ -38,7 +38,7 @@ public class IterableAssert_containsSequence_Test extends AbstractTest_for_Itera
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.containsSequence("Luke", "Yoda");
+    ConcreteIterableAssert<Object> returned = assertions.containsSequence("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_contains_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_contains_Test.java
@@ -36,7 +36,7 @@ public class IterableAssert_contains_Test extends AbstractTest_for_IterableAsser
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.contains("Luke");
+    ConcreteIterableAssert<Object> returned = assertions.contains("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveAtLeast_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_doNotHaveAtLeast_Test extends AbstractTest_for_Itera
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.doNotHaveAtLeast(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.doNotHaveAtLeast(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveAtMost_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_doNotHaveAtMost_Test extends AbstractTest_for_Iterab
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.doNotHaveAtMost(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.doNotHaveAtMost(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doNotHaveExactly_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_doNotHaveExactly_Test extends AbstractTest_for_Itera
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.doNotHaveExactly(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.doNotHaveExactly(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doNotHave_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doNotHave_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_doNotHave_Test extends AbstractTest_for_IterableAsse
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.doNotHave(condition);
+	    ConcreteIterableAssert<Object> returned = assertions.doNotHave(condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doesNotContain_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doesNotContain_Test.java
@@ -36,7 +36,7 @@ public class IterableAssert_doesNotContain_Test extends AbstractTest_for_Iterabl
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.doesNotContain("Luke");
+    ConcreteIterableAssert<Object> returned = assertions.doesNotContain("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_doesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_doesNotHaveDuplicates_Test.java
@@ -35,7 +35,7 @@ public class IterableAssert_doesNotHaveDuplicates_Test extends AbstractTest_for_
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.doesNotHaveDuplicates();
+    ConcreteIterableAssert<Object> returned = assertions.doesNotHaveDuplicates();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_endsWith_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_endsWith_Test.java
@@ -38,7 +38,7 @@ public class IterableAssert_endsWith_Test extends AbstractTest_for_IterableAsser
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.endsWith("Luke", "Yoda");
+    ConcreteIterableAssert<Object> returned = assertions.endsWith("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_hasSameSizeAs_with_Array_Test.java
@@ -37,7 +37,7 @@ public class IterableAssert_hasSameSizeAs_with_Array_Test extends AbstractTest_f
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.hasSameSizeAs(other);
+    ConcreteIterableAssert<Object> returned = assertions.hasSameSizeAs(other);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -39,7 +39,7 @@ public class IterableAssert_hasSameSizeAs_with_Iterable_Test extends AbstractTes
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.hasSameSizeAs(other);
+    ConcreteIterableAssert<Object> returned = assertions.hasSameSizeAs(other);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_hasSize_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_hasSize_Test.java
@@ -35,7 +35,7 @@ public class IterableAssert_hasSize_Test extends AbstractTest_for_IterableAssert
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.hasSize(0);
+    ConcreteIterableAssert<Object> returned = assertions.hasSize(0);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_haveAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_haveAtLeast_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_haveAtLeast_Test extends AbstractTest_for_IterableAs
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.haveAtLeast(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.haveAtLeast(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_haveAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_haveAtMost_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_haveAtMost_Test extends AbstractTest_for_IterableAss
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.areAtMost(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.areAtMost(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_haveExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_haveExactly_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_haveExactly_Test extends AbstractTest_for_IterableAs
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.haveExactly(2, condition);
+	    ConcreteIterableAssert<Object> returned = assertions.haveExactly(2, condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_have_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_have_Test.java
@@ -44,7 +44,7 @@ public class IterableAssert_have_Test extends AbstractTest_for_IterableAssert {
 
 	  @Test
 	  public void should_return_this() {
-	    ConcreteIterableAssert returned = assertions.have(condition);
+	    ConcreteIterableAssert<Object> returned = assertions.have(condition);
 	    assertSame(assertions, returned);
 	  }	
 	

--- a/src/test/java/org/fest/assertions/api/IterableAssert_isNotEmpty_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_isNotEmpty_Test.java
@@ -36,7 +36,7 @@ public class IterableAssert_isNotEmpty_Test extends AbstractTest_for_IterableAss
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.isNotEmpty();
+    ConcreteIterableAssert<Object> returned = assertions.isNotEmpty();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_isSubsetOf_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_isSubsetOf_Test.java
@@ -40,7 +40,7 @@ public class IterableAssert_isSubsetOf_Test extends AbstractTest_for_IterableAss
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.isSubsetOf(list("Luke"));
+    ConcreteIterableAssert<Object> returned = assertions.isSubsetOf(list("Luke"));
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/IterableAssert_startsWith_Test.java
+++ b/src/test/java/org/fest/assertions/api/IterableAssert_startsWith_Test.java
@@ -38,7 +38,7 @@ public class IterableAssert_startsWith_Test extends AbstractTest_for_IterableAss
 
   @Test
   public void should_return_this() {
-    ConcreteIterableAssert returned = assertions.startsWith("Luke", "Yoda");
+    ConcreteIterableAssert<Object> returned = assertions.startsWith("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_contains_at_Index_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_contains_at_Index_Test.java
@@ -14,7 +14,7 @@
  */
 package org.fest.assertions.api;
 
-import static java.util.Collections.emptyList;
+import java.util.Collections;
 import static junit.framework.Assert.assertSame;
 
 import static org.fest.assertions.test.TestData.someIndex;
@@ -36,11 +36,11 @@ import org.fest.assertions.internal.Lists;
 public class ListAssert_contains_at_Index_Test {
 
   private Lists lists;
-  private ListAssert assertions;
+  private ListAssert<String> assertions;
 
   @Before public void setUp() {
     lists = mock(Lists.class);
-    assertions = new ListAssert(emptyList());
+    assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertions.lists = lists;
   }
 
@@ -51,7 +51,7 @@ public class ListAssert_contains_at_Index_Test {
   }
 
   @Test public void should_return_this() {
-    ListAssert returned = assertions.contains("Luke", someIndex());
+    ListAssert<String> returned = assertions.contains("Luke", someIndex());
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_doesNotContain_at_Index_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_doesNotContain_at_Index_Test.java
@@ -14,14 +14,17 @@
  */
 package org.fest.assertions.api;
 
-import static java.util.Collections.emptyList;
 import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.TestData.someIndex;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
 
 import org.fest.assertions.data.Index;
 import org.fest.assertions.internal.Lists;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link ListAssert#doesNotContain(Object, Index)}</code>.
@@ -31,11 +34,11 @@ import org.junit.*;
 public class ListAssert_doesNotContain_at_Index_Test {
 
   private Lists lists;
-  private ListAssert assertions;
+  private ListAssert<String> assertions;
 
   @Before public void setUp() {
     lists = mock(Lists.class);
-    assertions = new ListAssert(emptyList());
+    assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertions.lists = lists;
   }
 
@@ -46,7 +49,7 @@ public class ListAssert_doesNotContain_at_Index_Test {
   }
 
   @Test public void should_return_this() {
-    ListAssert returned = assertions.doesNotContain("Luke", someIndex());
+    ListAssert<String> returned = assertions.doesNotContain("Luke", someIndex());
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_isSortedAccordingToComparator_Test.java
@@ -14,15 +14,18 @@
  */
 package org.fest.assertions.api;
 
-import static java.util.Collections.emptyList;
 import static junit.framework.Assert.assertSame;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Collections;
 import java.util.Comparator;
 
-import org.junit.Test;
-
 import org.fest.assertions.internal.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link AbstractIterableAssert#isSortedAccordingTo(Comparator)}</code>.
@@ -31,12 +34,18 @@ import org.fest.assertions.internal.Lists;
  */
 public class ListAssert_isSortedAccordingToComparator_Test {
 
-  private Comparator<?> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<String> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_actual_does_not_contain_null() {
     Lists lists = mock(Lists.class);
-    ListAssert assertions = new ListAssert(emptyList());
+    ListAssert<String> assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertions.lists = lists;
     assertions.isSortedAccordingTo(comparator);
     verify(lists).assertIsSortedAccordingToComparator(assertions.info, assertions.actual, comparator);
@@ -44,7 +53,7 @@ public class ListAssert_isSortedAccordingToComparator_Test {
 
   @Test
   public void should_return_this() {
-    ListAssert assertions = new ListAssert(emptyList());
+    ListAssert<String> assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertSame(assertions, assertions.isSortedAccordingTo(comparator));
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_isSorted_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_isSorted_Test.java
@@ -14,13 +14,14 @@
  */
 package org.fest.assertions.api;
 
-import static java.util.Collections.emptyList;
 import static junit.framework.Assert.assertSame;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import org.junit.Test;
+import java.util.Collections;
 
 import org.fest.assertions.internal.Lists;
+import org.junit.Test;
 
 /**
  * Tests for <code>{@link AbstractIterableAssert#isSorted()}</code>.
@@ -32,14 +33,14 @@ public class ListAssert_isSorted_Test {
   @Test
   public void should_verify_that_actual_does_not_contain_null() {
     Lists lists = mock(Lists.class);
-    ListAssert assertions = new ListAssert(emptyList());
+    ListAssert<String> assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertions.lists = lists;
     assertions.isSorted();
     verify(lists).assertIsSorted(assertions.info, assertions.actual);
   }
 
   @Test public void should_return_this() {
-    ListAssert assertions = new ListAssert(emptyList());
+    ListAssert<String> assertions = new ListAssert<String>(Collections.<String>emptyList());
     assertSame(assertions, assertions.isSorted());
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_usingComparator_Test.java
@@ -15,15 +15,18 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;
-
-import org.junit.Test;
+import java.util.Comparator;
+import java.util.List;
 
 import org.fest.assertions.internal.Iterables;
 import org.fest.assertions.internal.Lists;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ListAssert#usingComparator(java.util.Comparator)}</code> and
@@ -33,7 +36,15 @@ import org.fest.assertions.util.CaseInsensitiveStringComparator;
  */
 public class ListAssert_usingComparator_Test {
 
-  private ListAssert assertions = new ListAssert(new ArrayList<String>());
+  private ListAssert<String> assertions = new ListAssert<String>(new ArrayList<String>());
+
+  @Mock
+  private Comparator<List<String>> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void using_default_comparator_test() {
@@ -46,9 +57,9 @@ public class ListAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.iterables.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.lists.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.iterables.getComparator(), comparator);
+    assertSame(assertions.lists.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ListAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ListAssert_usingComparator_Test.java
@@ -33,6 +33,7 @@ import org.mockito.Mock;
  * <code>{@link ListAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ListAssert_usingComparator_Test {
 
@@ -53,13 +54,13 @@ public class ListAssert_usingComparator_Test {
     assertSame(assertions.iterables, Iterables.instance());
     assertSame(assertions.lists, Lists.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.iterables.getComparator(), comparator);
-    assertSame(assertions.lists.getComparator(), comparator);
+//    assertSame(assertions.iterables.getComparator(), Iterables.instance());
+//    assertSame(assertions.lists.getComparator(), Lists.instance());
   }
 }

--- a/src/test/java/org/fest/assertions/api/LongArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.LongArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.LongArrays;
 
@@ -33,8 +36,13 @@ import org.fest.assertions.internal.LongArrays;
  */
 public class LongArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Long> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Long> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/LongArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link LongArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class LongArrayAssert_usingComparator_Test {
 
-  private LongArrayAssert assertions = new LongArrayAssert(emptyArray());
+  private LongArrayAssert assertions;
 
+  @Mock
+  private Comparator<Long> elementComparator;
   @Mock
   private Comparator<long[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new LongArrayAssert(emptyArray());
   }
 
   @Test
@@ -50,12 +54,20 @@ public class LongArrayAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, LongArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, LongArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/LongArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.LongArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.LongArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link LongArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class LongArrayAssert_usingComparator_Test {
 
   private LongArrayAssert assertions = new LongArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<long[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class LongArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/LongAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Longs;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link LongAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class LongAssert_usingComparator_Test {
 
   private LongAssert assertions = new LongAssert(5L);
 
+  @Mock
+  private Comparator<Long> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class LongAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.longs.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.longs.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areAtLeast_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areAtLeast(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areAtLeast_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areAtMost_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areAtMost(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areAtMost_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areExactly_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areExactly(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areExactly_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotAtLeast_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areNotAtLeast(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areNotAtLeast_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotAtMost_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areNotAtMost(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areNotAtMost_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNotExactly_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areNotExactly(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areNotExactly_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNot_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_areNot_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#areNot(org.fest.assertions.core.Condition)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_areNot_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_are_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_are_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#are(org.fest.assertions.core.Condition)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_are_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsNull_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsNull_Test.java
@@ -28,15 +28,16 @@ import org.fest.assertions.internal.ObjectArrays;
  * Tests for <code>{@link ObjectArrayAssert#doesNotContainNull()}</code>.
  *
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_containsNull_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -46,7 +47,7 @@ public class ObjectArrayAssert_containsNull_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.containsNull();
+    ObjectArrayAssert<Object> returned = assertions.containsNull();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsOnly_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsOnly_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#containsOnly(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_containsOnly_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_containsOnly_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.containsOnly("Luke");
+    ObjectArrayAssert<Object> returned = assertions.containsOnly("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsSequence_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_containsSequence_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#containsSequence(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_containsSequence_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_containsSequence_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.containsSequence("Luke", "Yoda");
+    ObjectArrayAssert<Object> returned = assertions.containsSequence("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_contains_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_contains_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#contains(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_contains_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_contains_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.contains("Luke");
+    ObjectArrayAssert<Object> returned = assertions.contains("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_contains_at_Index_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_contains_at_Index_Test.java
@@ -27,15 +27,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#contains(Object, Index)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_contains_at_Index_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -46,7 +47,7 @@ public class ObjectArrayAssert_contains_at_Index_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.contains("Luke", someIndex());
+    ObjectArrayAssert<Object> returned = assertions.contains("Luke", someIndex());
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveAtLeast_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#doNotHaveAtLeas(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doNotHaveAtLeast_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveAtMost_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#doNotHaveAtMost(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doNotHaveAtMost_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNotHaveExactly_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#doNotHaveExactly(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doNotHaveExactly_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNothave_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doNothave_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#have(org.fest.assertions.core.Condition)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky 
  */
 public class ObjectArrayAssert_doNothave_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContainNull_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContainNull_Test.java
@@ -28,15 +28,16 @@ import org.fest.assertions.internal.ObjectArrays;
  * Tests for <code>{@link ObjectArrayAssert#doesNotContainNull()}</code>.
  *
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doesNotContainNull_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContain_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContain_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#doesNotContain(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doesNotContain_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_doesNotContain_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.doesNotContain("Luke");
+    ObjectArrayAssert<Object> returned = assertions.doesNotContain("Luke");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContain_at_Index_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotContain_at_Index_Test.java
@@ -27,15 +27,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#doesNotContain(Object, Index)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doesNotContain_at_Index_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -46,7 +47,7 @@ public class ObjectArrayAssert_doesNotContain_at_Index_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.doesNotContain("Luke", someIndex());
+    ObjectArrayAssert<Object> returned = assertions.doesNotContain("Luke", someIndex());
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotHaveDuplicates_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_doesNotHaveDuplicates_Test.java
@@ -25,15 +25,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#doesNotHaveDuplicates()}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_doesNotHaveDuplicates_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -43,7 +44,7 @@ public class ObjectArrayAssert_doesNotHaveDuplicates_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.doesNotHaveDuplicates();
+    ObjectArrayAssert<Object> returned = assertions.doesNotHaveDuplicates();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_endsWith_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_endsWith_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#endsWith(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_endsWith_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_endsWith_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.endsWith("Luke", "Yoda");
+    ObjectArrayAssert<Object> returned = assertions.endsWith("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
  * Tests for <code>{@link ObjectArrayAssert#hasSameSizeAs(Object[]))}</code>.
  *
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
   private final String[] other = array("Yoda");
 
   @Before
   public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -49,7 +50,7 @@ public class ObjectArrayAssert_hasSameSizeAs_with_Arrays_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.hasSameSizeAs(other);
+    ObjectArrayAssert<Object> returned = assertions.hasSameSizeAs(other);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -30,17 +30,18 @@ import org.junit.Test;
  * Tests for <code>{@link ObjectArrayAssert#hasSameSizeAs(int)}</code>.
  *
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
   private final List<String> other = list("Yoda");
 
   @Before
   public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -51,7 +52,7 @@ public class ObjectArrayAssert_hasSameSizeAs_with_Iterable_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.hasSameSizeAs(other);
+    ObjectArrayAssert<Object> returned = assertions.hasSameSizeAs(other);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSize_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_hasSize_Test.java
@@ -25,16 +25,17 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#hasSize(int)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_hasSize_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before
   public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -45,7 +46,7 @@ public class ObjectArrayAssert_hasSize_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.hasSize(0);
+    ObjectArrayAssert<Object> returned = assertions.hasSize(0);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveAtLeast_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveAtLeast_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#haveAtLeast(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_haveAtLeast_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveAtMost_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveAtMost_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#haveAtMost(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_haveAtMost_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveExactly_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_haveExactly_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#haveExactly(Condition, int)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_haveExactly_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_have_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_have_Test.java
@@ -28,17 +28,18 @@ import org.junit.Test;
 /**
  * Tests for <code>{@link ObjectArrayAssert#doNotHave(org.fest.assertions.core.Condition)}</code>.
  * 
- * @author Nicolas François 
+ * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_have_Test {
 
 	  private ObjectArrays arrays;
-	  private ObjectArrayAssert assertions;
+	  private ObjectArrayAssert<Object> assertions;
 	  private static Condition<Object> condition;
 
 	  @Before public void setUp() {
 	    arrays = mock(ObjectArrays.class);
-	    assertions = new ObjectArrayAssert(emptyArray());
+	    assertions = new ObjectArrayAssert<Object>(emptyArray());
 	    assertions.arrays = arrays;
 	    condition = new TestCondition<Object>();
 	  }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isEmpty_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isEmpty_Test.java
@@ -24,15 +24,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#isEmpty()}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_isEmpty_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isNotEmpty_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isNotEmpty_Test.java
@@ -25,15 +25,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#isNotEmpty()}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_isNotEmpty_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -43,7 +44,7 @@ public class ObjectArrayAssert_isNotEmpty_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.isNotEmpty();
+    ObjectArrayAssert<Object> returned = assertions.isNotEmpty();
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isNullOrEmpty_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isNullOrEmpty_Test.java
@@ -24,15 +24,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#isNullOrEmpty()}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_isNullOrEmpty_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSortedAccordingToComparator_Test.java
@@ -20,10 +20,13 @@ import static org.fest.assertions.test.ObjectArrayFactory.emptyArray;
 import static org.fest.util.Arrays.array;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.ObjectArrays;
 
@@ -34,7 +37,13 @@ import org.fest.assertions.internal.ObjectArrays;
  */
 public class ObjectArrayAssert_isSortedAccordingToComparator_Test {
 
-  private Comparator<?> mockComparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Object> mockComparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSortedAccordingToComparator_is_called() {

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSortedAccordingToComparator_Test.java
@@ -34,6 +34,7 @@ import org.fest.assertions.internal.ObjectArrays;
  * Tests for <code>{@link ObjectArrayAssert#isSortedAccordingTo(Comparator)}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_isSortedAccordingToComparator_Test {
 
@@ -48,7 +49,7 @@ public class ObjectArrayAssert_isSortedAccordingToComparator_Test {
   @Test
   public void should_verify_that_assertIsSortedAccordingToComparator_is_called() {
     ObjectArrays arrays = mock(ObjectArrays.class);
-    ObjectArrayAssert assertions = new ObjectArrayAssert(emptyArray());
+    ObjectArrayAssert<Object> assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
     assertions.isSortedAccordingTo(mockComparator);
     verify(arrays).assertIsSortedAccordingToComparator(assertions.info, assertions.actual,
@@ -57,7 +58,7 @@ public class ObjectArrayAssert_isSortedAccordingToComparator_Test {
 
   @Test
   public void should_return_this() {
-    ObjectArrayAssert objectArrayAssert = new ObjectArrayAssert(array("b", "a"));
+    ObjectArrayAssert<Object> objectArrayAssert = new ObjectArrayAssert<Object>(array("b", "a"));
     assertSame(objectArrayAssert, objectArrayAssert.isSortedAccordingTo(mockComparator));
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSorted_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_isSorted_Test.java
@@ -29,13 +29,14 @@ import org.fest.assertions.internal.ObjectArrays;
  * Tests for <code>{@link ObjectArrayAssert#isSorted()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_isSorted_Test {
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {
     ObjectArrays arrays = mock(ObjectArrays.class);
-    ObjectArrayAssert assertions = new ObjectArrayAssert(emptyArray());
+    ObjectArrayAssert<Object> assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
     assertions.isSorted();
     verify(arrays).assertIsSorted(assertions.info, assertions.actual);
@@ -43,7 +44,7 @@ public class ObjectArrayAssert_isSorted_Test {
 
   @Test
   public void should_return_this() {
-    ObjectArrayAssert objectArrayAssert = new ObjectArrayAssert(array("a", "b"));
+    ObjectArrayAssert<Object> objectArrayAssert = new ObjectArrayAssert<Object>(array("a", "b"));
     assertSame(objectArrayAssert, objectArrayAssert.isSorted());
   }
 

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_startsWith_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_startsWith_Test.java
@@ -26,15 +26,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectArrayAssert#startsWith(Object...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_startsWith_Test {
 
   private ObjectArrays arrays;
-  private ObjectArrayAssert assertions;
+  private ObjectArrayAssert<Object> assertions;
 
   @Before public void setUp() {
     arrays = mock(ObjectArrays.class);
-    assertions = new ObjectArrayAssert(emptyArray());
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
     assertions.arrays = arrays;
   }
 
@@ -44,7 +45,7 @@ public class ObjectArrayAssert_startsWith_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectArrayAssert returned = assertions.startsWith("Luke", "Yoda");
+    ObjectArrayAssert<Object> returned = assertions.startsWith("Luke", "Yoda");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.ObjectArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.ObjectArrays;
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ObjectArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class ObjectArrayAssert_usingComparator_Test {
 
   private ObjectArrayAssert assertions = new ObjectArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<Object[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -43,8 +53,8 @@ public class ObjectArrayAssert_usingComparator_Test {
   
   @Test
   public void using_custom_comparator_test() {
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link ObjectArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectArrayAssert_usingComparator_Test {
 
-  private ObjectArrayAssert assertions = new ObjectArrayAssert(emptyArray());
+  private ObjectArrayAssert<Object> assertions;
 
+  @Mock
+  private Comparator<Object> elementComparator;
   @Mock
   private Comparator<Object[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new ObjectArrayAssert<Object>(emptyArray());
   }
 
   @Test
@@ -50,11 +54,19 @@ public class ObjectArrayAssert_usingComparator_Test {
     assertSame(assertions.objects, Objects.instance());
     assertSame(assertions.arrays, ObjectArrays.instance());
   }
-  
+
   @Test
   public void using_custom_comparator_test() {
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, ObjectArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isInstanceOfAny_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isInstanceOfAny_Test.java
@@ -24,15 +24,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectAssert#isInstanceOfAny(Class...)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_isInstanceOfAny_Test {
 
   private Objects objects;
-  private ObjectAssert assertions;
+  private ObjectAssert<String> assertions;
 
   @Before public void setUp() {
     objects = mock(Objects.class);
-    assertions = new ObjectAssert("Yoda");
+    assertions = new ObjectAssert<String>("Yoda");
     assertions.objects = objects;
   }
 
@@ -43,7 +44,7 @@ public class ObjectAssert_isInstanceOfAny_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectAssert returned = assertions.isInstanceOfAny(String.class);
+    ObjectAssert<String> returned = assertions.isInstanceOfAny(String.class);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isInstanceOf_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isInstanceOf_Test.java
@@ -24,15 +24,16 @@ import org.junit.*;
  * Tests for <code>{@link ObjectAssert#isInstanceOf(Class)}</code>.
  *
  * @author Alex Ruiz
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_isInstanceOf_Test {
 
   private Objects objects;
-  private ObjectAssert assertions;
+  private ObjectAssert<String> assertions;
 
   @Before public void setUp() {
     objects = mock(Objects.class);
-    assertions = new ObjectAssert("Yoda");
+    assertions = new ObjectAssert<String>("Yoda");
     assertions.objects = objects;
   }
 
@@ -42,7 +43,7 @@ public class ObjectAssert_isInstanceOf_Test {
   }
 
   @Test public void should_return_this() {
-    ObjectAssert returned = assertions.isInstanceOf(String.class);
+    ObjectAssert<String> returned = assertions.isInstanceOf(String.class);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByAcceptingFields_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByAcceptingFields_Test.java
@@ -28,27 +28,28 @@ import org.junit.Test;
  * Tests for <code>{@link ObjectAssert#isLenientEqualsToByAcceptingFields(Object, String...)}</code>.
  *
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_isLenientEqualsToByAcceptingFields_Test {
 
   private Objects objects;
-  private ObjectAssert assertions;
+  private ObjectAssert<Jedi> assertions;
 
   @Before public void setUp() {
     objects = mock(Objects.class);
-    assertions = new ObjectAssert(new Jedi("Yoda", "Green"));
+    assertions = new ObjectAssert<Jedi>(new Jedi("Yoda", "Green"));
     assertions.objects = objects;
   }
 
   @Test public void should_verify_that_actual_is_instance_of_type() {
-	Object other = new Jedi("Yoda", "Blue");
+    Jedi other = new Jedi("Yoda", "Blue");
     assertions.isLenientEqualsToByAcceptingFields(other, "name");
     verify(objects).assertIsLenientEqualsToByAcceptingFields(assertions.info, assertions.actual, other, "name");
   }
 
   @Test public void should_return_this() {
-	Object other = new Jedi("Yoda", "Blue");
-    ObjectAssert returned = assertions.isLenientEqualsToByAcceptingFields(other, "name");
+    Jedi other = new Jedi("Yoda", "Blue");
+    ObjectAssert<Jedi> returned = assertions.isLenientEqualsToByAcceptingFields(other, "name");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByIgnoringFields_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByIgnoringFields_Test.java
@@ -28,27 +28,28 @@ import org.junit.Test;
  * Tests for <code>{@link ObjectAssert#isLenientEqualsToByIgnoringFields(Object, String...)}</code>.
  *
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_isLenientEqualsToByIgnoringFields_Test {
 
   private Objects objects;
-  private ObjectAssert assertions;
+  private ObjectAssert<Jedi> assertions;
 
   @Before public void setUp() {
     objects = mock(Objects.class);
-    assertions = new ObjectAssert(new Jedi("Yoda", "Green"));
+    assertions = new ObjectAssert<Jedi>(new Jedi("Yoda", "Green"));
     assertions.objects = objects;
   }
 
   @Test public void should_verify_that_actual_is_instance_of_type() {
-	Object other = new Jedi("Yoda", "Blue");
+    Jedi other = new Jedi("Yoda", "Blue");
     assertions.isLenientEqualsToByIgnoringFields(other, "lightSaberColor");
     verify(objects).assertIsLenientEqualsToByIgnoringFields(assertions.info, assertions.actual, other, "lightSaberColor");
   }
 
   @Test public void should_return_this() {
-	Object other = new Jedi("Yoda", "Blue");
-    ObjectAssert returned = assertions.isLenientEqualsToByIgnoringFields(other, "lightSaberColor");
+    Jedi other = new Jedi("Yoda", "Blue");
+    ObjectAssert<Jedi> returned = assertions.isLenientEqualsToByIgnoringFields(other, "lightSaberColor");
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByIgnoringNullFields_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isLenientEqualsToByIgnoringNullFields_Test.java
@@ -28,27 +28,28 @@ import org.junit.Test;
  * Tests for <code>{@link ObjectAssert#isLenientEqualsToByIgnoringNullFields(Object)}</code>.
  *
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_isLenientEqualsToByIgnoringNullFields_Test {
 
   private Objects objects;
-  private ObjectAssert assertions;
+  private ObjectAssert<Jedi> assertions;
 
   @Before public void setUp() {
     objects = mock(Objects.class);
-    assertions = new ObjectAssert(new Jedi("Yoda", "Green"));
+    assertions = new ObjectAssert<Jedi>(new Jedi("Yoda", "Green"));
     assertions.objects = objects;
   }
 
   @Test public void should_verify_that_actual_is_instance_of_type() {
-	Object other = new Jedi("Yoda", "Green");
+    Jedi other = new Jedi("Yoda", "Green");
     assertions.isLenientEqualsToByIgnoringNullFields(other);
     verify(objects).assertIsLenientEqualsToByIgnoringNullFields(assertions.info, assertions.actual, other);
   }
 
   @Test public void should_return_this() {
-	Object other = new Jedi("Yoda", "Green");
-    ObjectAssert returned = assertions.isLenientEqualsToByIgnoringNullFields(other);
+    Jedi other = new Jedi("Yoda", "Green");
+    ObjectAssert<Jedi> returned = assertions.isLenientEqualsToByIgnoringNullFields(other);
     assertSame(assertions, returned);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_usingComparator_Test.java
@@ -15,11 +15,14 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Objects;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ObjectAssert#usingComparator(java.util.Comparator)}</code> and
@@ -31,6 +34,14 @@ public class ObjectAssert_usingComparator_Test {
 
   private ObjectAssert assertions = new ObjectAssert(5L);
 
+  @Mock
+  private Comparator<Object> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -40,7 +51,7 @@ public class ObjectAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_usingComparator_Test.java
@@ -29,13 +29,14 @@ import org.mockito.Mock;
  * <code>{@link ObjectAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ObjectAssert_usingComparator_Test {
 
-  private ObjectAssert assertions = new ObjectAssert(5L);
+  private ObjectAssert<Long> assertions = new ObjectAssert<Long>(5L);
 
   @Mock
-  private Comparator<Object> comparator;
+  private Comparator<Long> comparator;
 
   @Before
   public void before(){

--- a/src/test/java/org/fest/assertions/api/ShortArrayAssert_isSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortArrayAssert_isSortedAccordingToComparator_Test.java
@@ -19,10 +19,13 @@ import static junit.framework.Assert.assertSame;
 import static org.fest.assertions.test.ShortArrayFactory.emptyArray;
 
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Comparator;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import org.fest.assertions.internal.ShortArrays;
 
@@ -33,8 +36,13 @@ import org.fest.assertions.internal.ShortArrays;
  */
 public class ShortArrayAssert_isSortedAccordingToComparator_Test {
 
-  @SuppressWarnings("unchecked")
-  private Comparator<? extends Short> comparator = mock(Comparator.class);
+  @Mock
+  private Comparator<Short> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
 
   @Test
   public void should_verify_that_assertIsSorted_is_called() {

--- a/src/test/java/org/fest/assertions/api/ShortArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortArrayAssert_usingComparator_Test.java
@@ -15,14 +15,16 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
-
 import static org.fest.assertions.test.ShortArrayFactory.emptyArray;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Objects;
 import org.fest.assertions.internal.ShortArrays;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ShortArrayAssert#usingComparator(java.util.Comparator)}</code> and
@@ -34,6 +36,14 @@ public class ShortArrayAssert_usingComparator_Test {
 
   private ShortArrayAssert assertions = new ShortArrayAssert(emptyArray());
 
+  @Mock
+  private Comparator<short[]> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -44,8 +54,8 @@ public class ShortArrayAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.arrays.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.arrays.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ShortArrayAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortArrayAssert_usingComparator_Test.java
@@ -31,17 +31,21 @@ import org.mockito.Mock;
  * <code>{@link ShortArrayAssert#usingDefaultComparator()}</code>.
  * 
  * @author Joel Costigliola
+ * @author Mikhail Mazursky
  */
 public class ShortArrayAssert_usingComparator_Test {
 
-  private ShortArrayAssert assertions = new ShortArrayAssert(emptyArray());
+  private ShortArrayAssert assertions;
 
+  @Mock
+  private Comparator<Short> elementComparator;
   @Mock
   private Comparator<short[]> comparator;
 
   @Before
   public void before(){
     initMocks(this);
+    assertions = new ShortArrayAssert(emptyArray());
   }
 
   @Test
@@ -56,6 +60,14 @@ public class ShortArrayAssert_usingComparator_Test {
     // in that test, the comparator type is not important, we only check that we correctly switch of comparator
     assertions.usingComparator(comparator);
     assertSame(assertions.objects.getComparator(), comparator);
-    assertSame(assertions.arrays.getComparator(), comparator);
+    assertSame(assertions.arrays, ShortArrays.instance());
+  }
+
+  @Test
+  public void using_custom_element_comparator_test() {
+    // in that, we don't care of the comparator, the point to check is that we can't use a comparator
+    assertions.usingElementComparator(elementComparator);
+    assertSame(assertions.objects, Objects.instance());
+    assertSame(assertions.arrays.getComparator(), elementComparator);
   }
 }

--- a/src/test/java/org/fest/assertions/api/ShortAssert_usingComparator_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortAssert_usingComparator_Test.java
@@ -15,12 +15,15 @@
 package org.fest.assertions.api;
 
 import static junit.framework.Assert.assertSame;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-import org.junit.Test;
+import java.util.Comparator;
 
 import org.fest.assertions.internal.Objects;
 import org.fest.assertions.internal.Shorts;
-import org.fest.assertions.util.CaseInsensitiveStringComparator;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 /**
  * Tests for <code>{@link ShortAssert#usingComparator(java.util.Comparator)}</code> and
@@ -32,6 +35,14 @@ public class ShortAssert_usingComparator_Test {
 
   private ShortAssert assertions = new ShortAssert((short)5);
 
+  @Mock
+  private Comparator<Short> comparator;
+
+  @Before
+  public void before(){
+    initMocks(this);
+  }
+
   @Test
   public void using_default_comparator_test() {
     assertions.usingDefaultComparator();
@@ -42,8 +53,8 @@ public class ShortAssert_usingComparator_Test {
   @Test
   public void using_custom_comparator_test() {
     // in that, we don't care of the comparator, the point to check is that we switch correctly of comparator
-    assertions.usingComparator(CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.objects.getComparator(), CaseInsensitiveStringComparator.instance);
-    assertSame(assertions.shorts.getComparator(), CaseInsensitiveStringComparator.instance);
+    assertions.usingComparator(comparator);
+    assertSame(assertions.objects.getComparator(), comparator);
+    assertSame(assertions.shorts.getComparator(), comparator);
   }
 }

--- a/src/test/java/org/fest/assertions/groups/Properties_extractProperty_Test.java
+++ b/src/test/java/org/fest/assertions/groups/Properties_extractProperty_Test.java
@@ -21,26 +21,27 @@ import org.fest.assertions.test.ExpectedException;
 import org.junit.*;
 
 /**
- * Tests for <code>{@link Properties#extractProperty(String)}</code>.
+ * Tests for <code>{@link Properties#extractProperty(String, Class)}</code>.
  *
  * @author Yvonne Wang
+ * @author Mikhail Mazursky
  */
 public class Properties_extractProperty_Test {
 
   @Rule public ExpectedException thrown = none();
 
   @Test public void should_create_a_new_Properties() {
-    Properties properties = Properties.extractProperty("id");
+    Properties<Object> properties = Properties.extractProperty("id", Object.class);
     assertEquals("id", properties.propertyName);
   }
 
   @Test public void should_throw_error_if_property_name_is_null() {
     thrown.expectNullPointerException("The name of the property to read should not be null");
-    Properties.extractProperty(null);
+    Properties.extractProperty(null, Object.class);
   }
 
   @Test public void should_throw_error_if_property_name_is_empty() {
     thrown.expectIllegalArgumentException("The name of the property to read should not be empty");
-    Properties.extractProperty("");
+    Properties.extractProperty("", Object.class);
   }
 }

--- a/src/test/java/org/fest/assertions/groups/Properties_from_with_Collection_Test.java
+++ b/src/test/java/org/fest/assertions/groups/Properties_from_with_Collection_Test.java
@@ -29,6 +29,7 @@ import org.junit.*;
  * Tests for <code>{@link Properties#from(Collection)}</code>.
  *
  * @author Yvonne Wang
+ * @author Mikhail Mazursky
  */
 public class Properties_from_with_Collection_Test {
 
@@ -42,19 +43,19 @@ public class Properties_from_with_Collection_Test {
 
   private PropertySupport propertySupport;
   private String propertyName;
-  private Properties properties;
+  private Properties<Long> properties;
 
   @Before public void setUp() {
     propertySupport = mock(PropertySupport.class);
     propertyName = "id";
-    properties = new Properties(propertyName);
+    properties = new Properties<Long>(propertyName, Long.class);
     properties.propertySupport = propertySupport;
   }
 
   @Test public void should_return_values_of_property() {
-    List<Object> ids = new ArrayList<Object>();
+    List<Long> ids = new ArrayList<Long>();
     ids.add(yoda.getId());
-    when(propertySupport.propertyValues(propertyName, employees)).thenReturn(ids);
+    when(propertySupport.propertyValues(propertyName, Long.class, employees)).thenReturn(ids);
     assertSame(ids, properties.from(employees));
   }
 }

--- a/src/test/java/org/fest/assertions/groups/Properties_from_with_array_Test.java
+++ b/src/test/java/org/fest/assertions/groups/Properties_from_with_array_Test.java
@@ -29,6 +29,7 @@ import org.junit.*;
  * Tests for <code>{@link Properties#from(Object[])}</code>.
  *
  * @author Yvonne Wang
+ * @author Mikhail Mazursky
  */
 public class Properties_from_with_array_Test {
 
@@ -42,19 +43,19 @@ public class Properties_from_with_array_Test {
 
   private PropertySupport propertySupport;
   private String propertyName;
-  private Properties properties;
+  private Properties<Long> properties;
 
   @Before public void setUp() {
     propertySupport = mock(PropertySupport.class);
     propertyName = "id";
-    properties = new Properties(propertyName);
+    properties = new Properties<Long>(propertyName, Long.class);
     properties.propertySupport = propertySupport;
   }
 
   @Test public void should_return_values_of_property() {
-    List<Object> ids = new ArrayList<Object>();
+    List<Long> ids = new ArrayList<Long>();
     ids.add(yoda.getId());
-    when(propertySupport.propertyValues(propertyName, wrap(employees))).thenReturn(ids);
+    when(propertySupport.propertyValues(propertyName, Long.class, wrap(employees))).thenReturn(ids);
     assertSame(ids, properties.from(employees));
   }
 }

--- a/src/test/java/org/fest/assertions/internal/Objects_assertIsIn_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Objects_assertIsIn_with_Iterable_Test.java
@@ -35,10 +35,11 @@ import org.junit.Test;
  * @author Alex Ruiz
  * @author Yvonne Wang
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class Objects_assertIsIn_with_Iterable_Test extends AbstractTest_for_Objects {
 
-  private static Iterable<?> values;
+  private static Iterable<String> values;
 
   @BeforeClass
   public static void setUpOnce() {
@@ -48,7 +49,7 @@ public class Objects_assertIsIn_with_Iterable_Test extends AbstractTest_for_Obje
   @Test
   public void should_throw_error_if_Iterable_is_null() {
     thrown.expectNullPointerException(iterableIsNull());
-    Iterable<?> c = null;
+    Iterable<String> c = null;
     objects.assertIsIn(someInfo(), "Yoda", c);
   }
 

--- a/src/test/java/org/fest/assertions/internal/Objects_assertIsNotIn_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Objects_assertIsNotIn_with_Iterable_Test.java
@@ -38,7 +38,7 @@ import org.junit.Test;
  */
 public class Objects_assertIsNotIn_with_Iterable_Test extends AbstractTest_for_Objects {
 
-  private static Iterable<?> values;
+  private static Iterable<String> values;
 
   @BeforeClass
   public static void setUpOnce() {
@@ -48,7 +48,7 @@ public class Objects_assertIsNotIn_with_Iterable_Test extends AbstractTest_for_O
   @Test
   public void should_throw_error_if_Iterable_is_null() {
     thrown.expectNullPointerException(iterableIsNull());
-    Iterable<?> c = null;
+    Iterable<String> c = null;
     objects.assertIsNotIn(someInfo(), "Luke", c);
   }
 

--- a/src/test/java/org/fest/assertions/internal/PropertySupport_propertyValues_Test.java
+++ b/src/test/java/org/fest/assertions/internal/PropertySupport_propertyValues_Test.java
@@ -36,6 +36,7 @@ import org.junit.Test;
  *
  * @author Yvonne Wang
  * @author Nicolas François
+ * @author Mikhail Mazursky
  */
 public class PropertySupport_propertyValues_Test {
 
@@ -54,43 +55,43 @@ public class PropertySupport_propertyValues_Test {
   @Rule public ExpectedException thrown = none();
 
   @Test public void should_return_empty_List_if_given_Collection_is_null() {
-    List<Object> ids = propertySupport.propertyValues("ids", null);
+    List<Long> ids = propertySupport.propertyValues("ids", Long.class, null);
     assertEquals(emptyList(), ids);
   }
 
   @Test public void should_return_empty_List_if_given_Collection_is_empty() {
-    List<Object> ids = propertySupport.propertyValues("ids", emptySet());
+    List<Long> ids = propertySupport.propertyValues("ids", Long.class, emptySet());
     assertEquals(emptyList(), ids);
   }
 
   @Test public void should_return_empty_List_if_given_Collection_contains_only_nulls() {
-    List<Object> ids = propertySupport.propertyValues("ids", list(null, null));
+    List<Long> ids = propertySupport.propertyValues("ids", Long.class, list(null, null));
     assertEquals(emptyList(), ids);
   }
 
   @Test public void should_remove_null_values_from_given_Collection() {
     List<Employee> anotherList = list(yoda, null, luke, null);
-    List<Object> ids = propertySupport.propertyValues("id", anotherList);
+    List<Long> ids = propertySupport.propertyValues("id", Long.class, anotherList);
     assertEquals(list(6000L, 8000L), ids);
   }
 
   @Test public void should_return_values_of_simple_property() {
-    List<Object> ids = propertySupport.propertyValues("id", employees);
+    List<Long> ids = propertySupport.propertyValues("id", Long.class, employees);
     assertEquals(list(6000L, 8000L), ids);
   }
 
   @Test public void should_return_values_of_nested_property() {
-    List<Object> firstNames = propertySupport.propertyValues("name.first", employees);
+    List<String> firstNames = propertySupport.propertyValues("name.first", String.class, employees);
     assertEquals(list("Yoda", "Luke"), firstNames);
   }
 
   @Test public void should_throw_error_if_property_not_found() {
     thrown.expect(IntrospectionError.class);
-    propertySupport.propertyValues("id.", employees);
+    propertySupport.propertyValues("id.", Long.class, employees);
   }
-  
+
   @Test public void should_extract_property(){
-	  long id = propertySupport.propertyValue("id", yoda, long.class);
-	  assertEquals(6000L, id);
+	  Long id = propertySupport.propertyValue("id", Long.class, yoda);
+	  assertEquals(Long.valueOf(6000L), id);
   }
 }

--- a/src/test/java/org/fest/assertions/internal/PropertySupport_propertyValues_with_mocks_Test.java
+++ b/src/test/java/org/fest/assertions/internal/PropertySupport_propertyValues_with_mocks_Test.java
@@ -31,6 +31,7 @@ import org.junit.*;
  * Tests for <code>{@link PropertySupport#propertyValues(String, Collection)}</code>.
  *
  * @author Yvonne Wang
+ * @author Mikhail Mazursky
  */
 public class PropertySupport_propertyValues_with_mocks_Test {
 
@@ -56,7 +57,7 @@ public class PropertySupport_propertyValues_with_mocks_Test {
     PropertyDescriptor real = descriptorForProperty("id", yoda);
     when(descriptor.invokeReadMethod(real, yoda)).thenThrow(thrownOnPurpose);
     try {
-      propertySupport.propertyValues("id", employees);
+      propertySupport.propertyValues("id", Long.class, employees);
       fail("expecting an IntrospectionError to be thrown");
     } catch (IntrospectionError expected) {
       assertSame(thrownOnPurpose, expected.getCause());


### PR DESCRIPTION
Hello.
I improved type safety and while refactoring noticed that some methods, that take `Comparator`, are incorrectly use `extends` instead of `super`. That shows that not only type safety helps to write correct tests but also to catch bugs in the assertion library itself.

What do you think?
