### PR TITLE
fix Lenient Equals By Ignoring Fields

### DIFF
--- a/src/main/java/org/fest/assertions/internal/Objects.java
+++ b/src/main/java/org/fest/assertions/internal/Objects.java
@@ -25,7 +25,8 @@ import static org.fest.assertions.error.ShouldNotBeEqual.shouldNotBeEqual;
 import static org.fest.assertions.error.ShouldNotBeIn.shouldNotBeIn;
 import static org.fest.assertions.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.fest.assertions.error.ShouldNotBeSame.shouldNotBeSame;
-import static org.fest.util.Collections.*;
+import static org.fest.util.Collections.list;
+import static org.fest.util.Collections.set;
 import static org.fest.util.ToString.toStringOf;
 
 import java.lang.reflect.Field;
@@ -392,14 +393,13 @@ public class Objects {
 		for (Field field : actual.getClass().getDeclaredFields()) {
 			try {
 				if (!ignoredFields.contains(field.getName())) {
-					Object otherFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), other);
-					if (otherFieldValue != null) {
-						Object actualFieldValue = propertySupport.propertyValue(field.getName(), field.getType(), actual);
-						if (!otherFieldValue.equals(actualFieldValue)) {
-							fieldsNames.add(field.getName());
-							values.add(otherFieldValue);
-						}
-					}
+					String fieldName = field.getName();
+			  		Object actualFieldValue = propertySupport.propertyValue(fieldName, Object.class, actual);
+			  		Object otherFieldValue = propertySupport.propertyValue(fieldName, Object.class, other);
+			  		if (!(actualFieldValue == otherFieldValue || (actualFieldValue != null && actualFieldValue.equals(otherFieldValue)))) {
+			  			fieldsNames.add(fieldName);
+			  			values.add(otherFieldValue);				
+			  		}
 				}
 			} catch (IntrospectionError e) {
 				// Not readeable field, skip.

--- a/src/test/java/org/fest/assertions/internal/Objects_assertIsLenientEqualsToByIgnoringFields_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Objects_assertIsLenientEqualsToByIgnoringFields_Test.java
@@ -88,4 +88,18 @@ public class Objects_assertIsLenientEqualsToByIgnoringFields_Test {
     failBecauseExpectedAssertionErrorWasNotThrown();
   }   
   
+  @Test 
+  public void should_fail_when_value_is_null_just_on_other() {
+	AssertionInfo info = someInfo();
+	Jedi actual = new Jedi("Yoda", "Green");
+	Jedi other = new Jedi("Yoda", null);
+	try {
+	  objects.assertIsLenientEqualsToByIgnoringFields(info, actual, other, "name");
+	} catch (AssertionError err) {
+		verify(failures).failure(info, shouldBeLenientEqualByIgnoring(actual, list("lightSaberColor"), list((Object) null), list("name"))); 
+		return;
+	}
+	failBecauseExpectedAssertionErrorWasNotThrown();	
+  }   
+  
 }


### PR DESCRIPTION
I found a when other value is null on lenient assert by ignoring fields.
