### PR TITLE
isEqualsToByComparingFields (old title was : isLenientEqualsTo)

### DIFF
--- a/src/main/java/org/fest/assertions/api/ObjectAssert.java
+++ b/src/main/java/org/fest/assertions/api/ObjectAssert.java
@@ -152,5 +152,30 @@ public class ObjectAssert<T> extends AbstractAssert<ObjectAssert<T>, T> {
     objects.assertIsLenientEqualsToByIgnoringFields(info, actual, other, fields);
     return this;
   }
+  
+  /**
+   * Assert that the actual object is equals fields by fields to another object.
+   * 
+   * <pre>
+   * Example: 
+   * 
+   * TolkienCharacter frodo = new TolkienCharacter("Frodo", 33, HOBBIT); 
+   * TolkienCharacter frodoClone = new TolkienCharacter("Frodo", 33, HOBBIT); 
+   * 
+   * // frodo and frodoClone are equals by comparing fields
+   * assertThat(frodo).isLenientEqualsToByIgnoringFields(frodoClone); //=> OK
+   * 
+   * </pre>
+   *  
+   * @param other the object to compare {@code actual} to.
+   * @throws NullPointerException if the actual type is {@code null}.
+   * @throws NullPointerException if the other type is {@code null}.
+   * @throws AssertionError if the actual and the given object are not equals fields by fields.
+   * @throws AssertionError if the other object is not an instance of the actual type.
+   */
+  public ObjectAssert<T> isEqualsToByComparingFields(T other){
+	 objects.assertIsLenientEqualsToByIgnoringFields(info, actual, other);
+	 return this;
+  }
 
 }

--- a/src/test/java/org/fest/assertions/api/ObjectAssert_isEqualsToByComparingFields_Test.java
+++ b/src/test/java/org/fest/assertions/api/ObjectAssert_isEqualsToByComparingFields_Test.java
@@ -1,0 +1,54 @@
+/*
+
+ * Created on May 27, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.internal.Objects;
+import org.fest.assertions.test.Jedi;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ObjectAssert#isEqualsToByComparingFields(Object)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ObjectAssert_isEqualsToByComparingFields_Test {
+
+  private Objects objects;
+  private ObjectAssert<Jedi> assertions;
+
+  @Before public void setUp() {
+    objects = mock(Objects.class);
+    assertions = new ObjectAssert<Jedi>(new Jedi("Yoda", "Green"));
+    assertions.objects = objects;
+  }
+
+  @Test public void should_verify_that_actual_is_instance_of_type() {
+    Jedi other = new Jedi("Yoda", "Blue");
+    assertions.isEqualsToByComparingFields(other);
+    verify(objects).assertIsLenientEqualsToByIgnoringFields(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    Jedi other = new Jedi("Yoda", "Blue");
+    ObjectAssert<Jedi> returned = assertions.isEqualsToByComparingFields(other);
+    assertSame(assertions, returned);
+  }
+}


### PR DESCRIPTION
To continue on Brian comment on FEST-470

https://jira.codehaus.org/browse/FEST-470?focusedCommentId=294453&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-294453

I think it's a good idea.
I 'm not sure the "isLenientEqualsTo" is the better method name :
pro : the equals is close to other lenientEquals and user can find easily
cons : not really "lenient"

The error message is the same as other lenient equals.

As Brian say, this method could just be a alias on isLenientEqualsToByIgnoringFields(expected) without ignoring fields.

I can work on it this weekend.
