### PR TITLE
hasSameSize on *ArrayAssert

### DIFF
--- a/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/BooleanArrayAssert.java
@@ -32,6 +32,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boolean[]> implements
     EnumerableAssert<BooleanArrayAssert, Boolean>, ArraySortedAssert<BooleanArrayAssert, Boolean> {
@@ -64,6 +65,18 @@ public class BooleanArrayAssert extends AbstractAssert<BooleanArrayAssert, boole
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public BooleanArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public BooleanArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  } 
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ByteArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> implements
     EnumerableAssert<ByteArrayAssert, Byte>, ArraySortedAssert<ByteArrayAssert, Byte> {
@@ -65,6 +66,18 @@ public class ByteArrayAssert extends AbstractAssert<ByteArrayAssert, byte[]> imp
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public ByteArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public ByteArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/CharArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/CharArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> implements
     EnumerableAssert<CharArrayAssert, Character>, ArraySortedAssert<CharArrayAssert, Character> {
@@ -65,6 +66,18 @@ public class CharArrayAssert extends AbstractAssert<CharArrayAssert, char[]> imp
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public CharArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public CharArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }    
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/DoubleArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[]> implements
     EnumerableAssert<DoubleArrayAssert, Double>, ArraySortedAssert<DoubleArrayAssert, Double> {
@@ -65,6 +66,18 @@ public class DoubleArrayAssert extends AbstractAssert<DoubleArrayAssert, double[
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public DoubleArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public DoubleArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }  
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/FloatArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> implements
     EnumerableAssert<FloatArrayAssert, Float>, ArraySortedAssert<FloatArrayAssert, Float> {
@@ -65,6 +66,18 @@ public class FloatArrayAssert extends AbstractAssert<FloatArrayAssert, float[]> 
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public FloatArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public FloatArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }  
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/IntArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/IntArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implements EnumerableAssert<IntArrayAssert, Integer>,
     ArraySortedAssert<IntArrayAssert, Integer> {
@@ -65,6 +66,18 @@ public class IntArrayAssert extends AbstractAssert<IntArrayAssert, int[]> implem
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public IntArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public IntArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/LongArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/LongArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> implements
     EnumerableAssert<LongArrayAssert, Long>, ArraySortedAssert<LongArrayAssert, Long> {
@@ -65,6 +66,18 @@ public class LongArrayAssert extends AbstractAssert<LongArrayAssert, long[]> imp
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public LongArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public LongArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/MapAssert.java
+++ b/src/main/java/org/fest/assertions/api/MapAssert.java
@@ -63,6 +63,18 @@ public class MapAssert<K, V> extends AbstractAssert<MapAssert<K, V>, Map<K,V>> i
     maps.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public MapAssert<K, V> hasSameSizeAs(Object[] other) {
+	maps.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public MapAssert<K, V> hasSameSizeAs(Iterable<?> other) {
+	maps.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual map contains the given entries, in any order.

--- a/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
+++ b/src/main/java/org/fest/assertions/api/ShortArrayAssert.java
@@ -33,6 +33,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> implements
     EnumerableAssert<ShortArrayAssert, Short>, ArraySortedAssert<ShortArrayAssert, Short> {
@@ -65,6 +66,18 @@ public class ShortArrayAssert extends AbstractAssert<ShortArrayAssert, short[]> 
     arrays.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public ShortArrayAssert hasSameSizeAs(Object[] other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public ShortArrayAssert hasSameSizeAs(Iterable<?> other) {
+	arrays.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/api/StringAssert.java
+++ b/src/main/java/org/fest/assertions/api/StringAssert.java
@@ -34,6 +34,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class StringAssert extends AbstractAssert<StringAssert, String> implements EnumerableAssert<StringAssert, String> {
 
@@ -64,6 +65,18 @@ public class StringAssert extends AbstractAssert<StringAssert, String> implement
     strings.assertHasSize(info, actual, expected);
     return this;
   }
+  
+  /** {@inheritDoc} */
+  public StringAssert hasSameSizeAs(Object[] other) {
+	strings.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }
+  
+  /** {@inheritDoc} */
+  public StringAssert hasSameSizeAs(Iterable<?> other) {
+	strings.assertHasSameSizeAs(info, actual, other);
+    return this;
+  }   
 
   /**
    * Verifies that the actual {@code String} is equal to the given one, ignoring case considerations.

--- a/src/main/java/org/fest/assertions/core/EnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/EnumerableAssert.java
@@ -26,6 +26,7 @@ import java.util.Comparator;
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public interface EnumerableAssert<S extends EnumerableAssert<S, T>, T> {
 
@@ -55,7 +56,27 @@ public interface EnumerableAssert<S extends EnumerableAssert<S, T>, T> {
    * @throws AssertionError if the number of values of the actual group is not equal to the given one.
    */
   S hasSize(int expected);
+  
+  /**
+   * Verifies that the actual group has the same size as given {@link Iterable}.
+   * @param other the {@code Iterable} to compare size with actual group.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other {@code Iterable} is {@code null}.
+   * @throws AssertionError if actual group and given {@code Iterable} don't have the same size.
+   */
+  S hasSameSizeAs(Iterable<?> other);  
 
+  /**
+   * Verifies that the actual group has the same size as given array.
+   * @param other the array to compare size with actual group.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other array is {@code null}.
+   * @throws AssertionError if actual group and given array don't have the same size.
+   */
+  S hasSameSizeAs(Object[] other);  
+  
   /**
    * Use given custom comparator instead of relying on actual type A <code>equals</code> method to compare group
    * elements for incoming assertion checks.

--- a/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
+++ b/src/main/java/org/fest/assertions/core/ObjectEnumerableAssert.java
@@ -27,6 +27,7 @@ package org.fest.assertions.core;
  * @author Nicolas François
  * @author Mikhail Mazursky
  * @author Joel Costigliola
+ * @author Nicolas François
  */
 public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, T> extends EnumerableAssert<S, T> {
 
@@ -123,26 +124,6 @@ public interface ObjectEnumerableAssert<S extends ObjectEnumerableAssert<S, T>, 
    * @throws AssertionError if the actual group contains a null element.
    */
   S doesNotContainNull();
-
-  /**
-   * Verifies that the actual group has the same size as given array.
-   * @param other the array to compare size with actual group.
-   * @return {@code this} assertion object.
-   * @throws AssertionError if the actual group is {@code null}.
-   * @throws AssertionError if the other array is {@code null}.
-   * @throws AssertionError if actual group and given array don't have the same size.
-   */
-  S hasSameSizeAs(Object[] other);
-
-  /**
-   * Verifies that the actual group has the same size as given {@link Iterable}.
-   * @param other the {@code Iterable} to compare size with actual group.
-   * @return {@code this} assertion object.
-   * @throws AssertionError if the actual group is {@code null}.
-   * @throws AssertionError if the other {@code Iterable} is {@code null}.
-   * @throws AssertionError if actual group and given {@code Iterable} don't have the same size.
-   */
-  S hasSameSizeAs(Iterable<?> other);
 
   /**
    * Verifies that each element value satisfies the given condition

--- a/src/main/java/org/fest/assertions/internal/BooleanArrays.java
+++ b/src/main/java/org/fest/assertions/internal/BooleanArrays.java
@@ -16,7 +16,8 @@ package org.fest.assertions.internal;
 
 import java.util.Comparator;
 
-import org.fest.assertions.core.*;
+import org.fest.assertions.core.ArraySortedAssert;
+import org.fest.assertions.core.AssertionInfo;
 import org.fest.assertions.data.Index;
 import org.fest.util.VisibleForTesting;
 
@@ -26,6 +27,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class BooleanArrays {
 
@@ -90,6 +92,32 @@ public class BooleanArrays {
   public void assertHasSize(AssertionInfo info, boolean[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, boolean[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, boolean[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }    
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/ByteArrays.java
+++ b/src/main/java/org/fest/assertions/internal/ByteArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class ByteArrays {
 
@@ -103,6 +104,32 @@ public class ByteArrays {
   public void assertHasSize(AssertionInfo info, byte[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, byte[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, byte[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }   
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/CharArrays.java
+++ b/src/main/java/org/fest/assertions/internal/CharArrays.java
@@ -29,6 +29,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class CharArrays {
 
@@ -104,6 +105,32 @@ public class CharArrays {
   public void assertHasSize(AssertionInfo info, char[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, char[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, char[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }  
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/DoubleArrays.java
+++ b/src/main/java/org/fest/assertions/internal/DoubleArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  *
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class DoubleArrays {
 
@@ -101,6 +102,32 @@ public class DoubleArrays {
   public void assertHasSize(AssertionInfo info, double[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, double[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, double[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }   
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/FloatArrays.java
+++ b/src/main/java/org/fest/assertions/internal/FloatArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  *
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class FloatArrays {
 
@@ -102,6 +103,32 @@ public class FloatArrays {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
 
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, float[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, float[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }   
+  
   /**
    * Asserts that the given array contains the given values, in any order.
    * @param info contains information about the assertion.

--- a/src/main/java/org/fest/assertions/internal/IntArrays.java
+++ b/src/main/java/org/fest/assertions/internal/IntArrays.java
@@ -29,6 +29,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class IntArrays {
 
@@ -104,6 +105,32 @@ public class IntArrays {
   public void assertHasSize(AssertionInfo info, int[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, int[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, int[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }   
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/LongArrays.java
+++ b/src/main/java/org/fest/assertions/internal/LongArrays.java
@@ -29,6 +29,7 @@ import org.fest.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class LongArrays {
 
@@ -103,6 +104,32 @@ public class LongArrays {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
 
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, long[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, long[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }    
+  
   /**
    * Asserts that the given array contains the given values, in any order.
    * @param info contains information about the assertion.

--- a/src/main/java/org/fest/assertions/internal/Maps.java
+++ b/src/main/java/org/fest/assertions/internal/Maps.java
@@ -16,22 +16,27 @@ package org.fest.assertions.internal;
 
 import static org.fest.assertions.error.ShouldNotContain.shouldNotContain;
 import static org.fest.assertions.error.ShouldContain.shouldContain;
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.fest.assertions.error.ShouldHaveSize.shouldHaveSize;
 import static org.fest.assertions.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.fest.assertions.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.fest.assertions.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
+import static org.fest.assertions.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 import static org.fest.util.Objects.areEqual;
 
+import java.lang.reflect.Array;
 import java.util.*;
 
 import org.fest.assertions.core.AssertionInfo;
 import org.fest.assertions.data.MapEntry;
+import org.fest.util.Collections;
 import org.fest.util.VisibleForTesting;
 
 /**
  * Reusable assertions for <code>{@link Map}</code>s.
  *
  * @author Alex Ruiz
+ * @author Nicolas François
  */
 public class Maps {
 
@@ -100,7 +105,43 @@ public class Maps {
     if (sizeOfActual == expectedSize) return;
     throw failures.failure(info, shouldHaveSize(actual, sizeOfActual, expectedSize));
   }
-
+  
+  /**
+   * Asserts that the number of entries in the given {@code Map} has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param other the group to compare 
+   * @throws AssertionError if the given {@code Map} is {@code null}.
+   * @throws AssertionError if the given {@code Iterable} is {@code null}. 
+   * @throws AssertionError if the number of entries in the given {@code Map} does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, Map<?, ?> map, Iterable<?> other) {
+	assertNotNull(info, map);
+	if(other == null) throw new NullPointerException("The iterable to look for should not be null");
+	int sizeOfActual = map.size();
+	int sizeOfOther = Collections.sizeOf(other);
+	if(sizeOfActual == sizeOfOther) return;
+	throw failures.failure(info, shouldHaveSameSizeAs(map, sizeOfActual, sizeOfOther));
+  }
+  
+  /**
+   * Asserts that the number of entries in the given {@code Map} has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given {@code Map}.
+   * @param other the group to compare 
+   * @throws AssertionError if the given {@code Map} is {@code null}.
+   * @throws AssertionError if the given array is {@code null}. 
+   * @throws AssertionError if the number of entries in the given {@code Map} does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, Map<?, ?> map, Object[] other) {
+	assertNotNull(info, map);
+	if(other == null) throw arrayOfValuesToLookForIsNull();
+	int sizeOfActual = map.size();
+	int sizeOfOther = Array.getLength(other);
+	if(sizeOfActual == sizeOfOther) return;
+	throw failures.failure(info, shouldHaveSameSizeAs(map, sizeOfActual, sizeOfOther));	
+  }
+  
   /**
    * Asserts that the given {@code Map} contains the given entries, in any order.
    * @param info contains information about the assertion.

--- a/src/main/java/org/fest/assertions/internal/ShortArrays.java
+++ b/src/main/java/org/fest/assertions/internal/ShortArrays.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  * 
  * @author Alex Ruiz
  * @author Mikhail Mazursky
+ * @author Nicolas François
  */
 public class ShortArrays {
 
@@ -103,6 +104,32 @@ public class ShortArrays {
   public void assertHasSize(AssertionInfo info, short[] actual, int expectedSize) {
     arrays.assertHasSize(info, failures, actual, expectedSize);
   }
+  
+  /**
+   * Assert that the actual array has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, short[] actual, Iterable<?> other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }
+  
+  /**
+   * Assert that the actual array has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given array.
+   * @param other the group to compare 
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the other group is {@code null}.
+   * @throws AssertionError if the actual group does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, short[] actual, Object[] other) {
+    arrays.assertHasSameSizeAs(info, failures, actual, other);
+  }    
 
   /**
    * Asserts that the given array contains the given values, in any order.

--- a/src/main/java/org/fest/assertions/internal/Strings.java
+++ b/src/main/java/org/fest/assertions/internal/Strings.java
@@ -17,20 +17,25 @@ package org.fest.assertions.internal;
 import static org.fest.assertions.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.fest.assertions.error.ShouldBeEqualIgnoringCase.shouldBeEqual;
 import static org.fest.assertions.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
-import static org.fest.assertions.error.ShouldContainString.*;
+import static org.fest.assertions.error.ShouldContainString.shouldContain;
+import static org.fest.assertions.error.ShouldContainString.shouldContainIgnoringCase;
 import static org.fest.assertions.error.ShouldEndWith.shouldEndWith;
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.fest.assertions.error.ShouldHaveSize.shouldHaveSize;
 import static org.fest.assertions.error.ShouldMatchPattern.shouldMatch;
 import static org.fest.assertions.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.fest.assertions.error.ShouldNotContainString.shouldNotContain;
 import static org.fest.assertions.error.ShouldNotMatchPattern.shouldNotMatch;
 import static org.fest.assertions.error.ShouldStartWith.shouldStartWith;
+import static org.fest.assertions.internal.CommonErrors.arrayOfValuesToLookForIsNull;
 
+import java.lang.reflect.Array;
 import java.util.Comparator;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.fest.assertions.core.AssertionInfo;
+import org.fest.util.Collections;
 import org.fest.util.ComparatorBasedComparisonStrategy;
 import org.fest.util.ComparisonStrategy;
 import org.fest.util.StandardComparisonStrategy;
@@ -41,6 +46,7 @@ import org.fest.util.VisibleForTesting;
  *
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Nicolas François
  */
 public class Strings {
 
@@ -129,6 +135,42 @@ public class Strings {
     if (sizeOfActual == expectedSize) return;
     throw failures.failure(info, shouldHaveSize(actual, sizeOfActual, expectedSize));
   }
+  
+  /**
+   * Asserts that the number of entries in the given {@code String} has the same size as the other {@code Iterable}.
+   * @param info contains information about the assertion.
+   * @param actual the given {@code String}.
+   * @param other the group to compare 
+   * @throws AssertionError if the given {@code String}. is {@code null}.
+   * @throws AssertionError if the given {@code Iterable} is {@code null}. 
+   * @throws AssertionError if the number of entries in the given {@code String} does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, String actual, Iterable<?> other) {
+	assertNotNull(info, actual);
+	if(other == null) throw new NullPointerException("The iterable to look for should not be null");
+	int sizeOfActual = actual.length();
+	int sizeOfOther = Collections.sizeOf(other);
+	if(sizeOfActual == sizeOfOther) return;
+	throw failures.failure(info, shouldHaveSameSizeAs(actual, sizeOfActual, sizeOfOther));
+  }
+  
+  /**
+   * Asserts that the number of entries in the given {@code String} has the same size as the other array.
+   * @param info contains information about the assertion.
+   * @param actual the given {@code String}.
+   * @param other the group to compare 
+   * @throws AssertionError if the given {@code String} is {@code null}.
+   * @throws AssertionError if the given array is {@code null}. 
+   * @throws AssertionError if the number of entries in the given {@code String} does not have the same size.
+   */
+  public void assertHasSameSizeAs(AssertionInfo info, String actual, Object[] other) {
+	assertNotNull(info, actual);
+	if(other == null) throw arrayOfValuesToLookForIsNull();
+	int sizeOfActual = actual.length();
+	int sizeOfOther = Array.getLength(other);
+	if(sizeOfActual == sizeOfOther) return;
+	throw failures.failure(info, shouldHaveSameSizeAs(actual, sizeOfActual, sizeOfOther));	
+  }  
 
   /**
    * Verifies that the given {@code String} contains the given sequence.

--- a/src/test/java/org/fest/assertions/api/BooleanArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.BooleanArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.BooleanArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link BooleanArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class BooleanArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private BooleanArrays arrays;
+  private BooleanArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(BooleanArrays.class);
+    assertions = new BooleanArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    BooleanArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/BooleanArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/BooleanArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.BooleanArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.BooleanArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BooleanArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class BooleanArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+ private BooleanArrays arrays;
+ private BooleanArrayAssert assertions;
+ private final List<String> other = list("Yoda", "Luke");
+ 
+ @Before
+ public void setUp() {
+   arrays = mock(BooleanArrays.class);
+   assertions = new BooleanArrayAssert(emptyArray());
+   assertions.arrays = arrays;
+ }
+
+ @Test
+ public void should_verify_that_actual_has_expected_size() {
+   assertions.hasSameSizeAs(other);
+   verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+ }
+
+ @Test public void should_return_this() {
+   BooleanArrayAssert returned = assertions.hasSameSizeAs(other);
+   assertSame(assertions, returned);
+ }
+}

--- a/src/test/java/org/fest/assertions/api/ByteArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.ByteArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.internal.ByteArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ByteArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ByteArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private ByteArrays arrays;
+  private ByteArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(ByteArrays.class);
+    assertions = new ByteArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	ByteArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/ByteArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/ByteArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.ByteArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.ByteArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ByteArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ByteArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private ByteArrays arrays;
+  private ByteArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(ByteArrays.class);
+    assertions = new ByteArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	ByteArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/CharArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.CharArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.CharArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link CharArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class CharArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private CharArrays arrays;
+  private CharArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(CharArrays.class);
+    assertions = new CharArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    CharArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/CharArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/CharArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.CharArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.CharArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link CharArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class CharArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private CharArrays arrays;
+  private CharArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(CharArrays.class);
+    assertions = new CharArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	CharArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/DoubleArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.DoubleArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.DoubleArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link DoubleArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class DoubleArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private DoubleArrays arrays;
+  private DoubleArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(DoubleArrays.class);
+    assertions = new DoubleArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    DoubleArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/DoubleArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/DoubleArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.DoubleArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.DoubleArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link DoubleArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class DoubleArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private DoubleArrays arrays;
+  private DoubleArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(DoubleArrays.class);
+    assertions = new DoubleArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	DoubleArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/FloatArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.FloatArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.FloatArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link FloatArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class FloatArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private FloatArrays arrays;
+  private FloatArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(FloatArrays.class);
+    assertions = new FloatArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    FloatArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/FloatArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/FloatArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.FloatArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.FloatArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link FloatArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class FloatArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private FloatArrays arrays;
+  private FloatArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(FloatArrays.class);
+    assertions = new FloatArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	FloatArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/IntArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.IntArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.IntArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link IntArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class IntArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private IntArrays arrays;
+  private IntArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(IntArrays.class);
+    assertions = new IntArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    IntArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/IntArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/IntArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.IntArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.IntArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link IntArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class IntArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private IntArrays arrays;
+  private IntArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(IntArrays.class);
+    assertions = new IntArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	IntArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/LongArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.LongArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.LongArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class LongArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private LongArrays arrays;
+  private LongArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(LongArrays.class);
+    assertions = new LongArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    LongArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/LongArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/LongArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.LongArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.LongArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class LongArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private LongArrays arrays;
+  private LongArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(LongArrays.class);
+    assertions = new LongArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	LongArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/MapAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/MapAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,54 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static java.util.Collections.emptyMap;
+import static junit.framework.Assert.assertSame;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.internal.Maps;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link MapsAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class MapAssert_hasSameSizeAs_with_Array_Test {
+
+  private Maps maps;
+  private MapAssert<Object, Object> assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before public void setUp() {
+    maps = mock(Maps.class);
+    assertions = new MapAssert<Object, Object>(emptyMap());
+    assertions.maps = maps;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(maps).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	MapAssert<?, ?> returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/MapAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/MapAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static java.util.Collections.emptyMap;
+import static junit.framework.Assert.assertSame;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.Maps;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link MapsAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class MapAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private Maps maps;
+  private MapAssert<Object, Object> assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before public void setUp() {
+    maps = mock(Maps.class);
+    assertions = new MapAssert<Object, Object>(emptyMap());
+    assertions.maps = maps;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(maps).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	MapAssert<?, ?> returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/ShortArrayAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortArrayAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.ShortArrayFactory.emptyArray;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.*;
+
+import org.fest.assertions.internal.ShortArrays;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link ShortArrayAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ShortArrayAssert_hasSameSizeAs_with_Array_Test {
+
+  private ShortArrays arrays;
+  private ShortArrayAssert assertions;
+  private final String[] other = array("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(ShortArrays.class);
+    assertions = new ShortArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    ShortArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/ShortArrayAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/ShortArrayAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.assertions.test.ShortArrayFactory.emptyArray;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.ShortArrays;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ShortArrayAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ShortArrayAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private ShortArrays arrays;
+  private ShortArrayAssert assertions;
+  private final List<String> other = list("Yoda", "Luke");
+  
+  @Before
+  public void setUp() {
+    arrays = mock(ShortArrays.class);
+    assertions = new ShortArrayAssert(emptyArray());
+    assertions.arrays = arrays;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    assertions.hasSameSizeAs(other);
+    verify(arrays).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	ShortArrayAssert returned = assertions.hasSameSizeAs(other);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/StringAssert_hasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/api/StringAssert_hasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.Strings;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link StringAssert#hasSameSizeAs(Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class StringAssert_hasSameSizeAs_with_Array_Test {
+
+  private Strings strings;
+  private StringAssert assertions;
+  
+  @Before
+  public void setUp() {
+	strings = mock(Strings.class);
+    assertions = new StringAssert("Yoda");
+    assertions.strings = strings;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+    List<String> other = list("Luke");  
+    assertions.hasSameSizeAs(other);
+    verify(strings).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+    StringAssert returned = assertions.hasSameSizeAs(list("Luke"));
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/StringAssert_hasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/api/StringAssert_hasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.internal.Strings;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link StringAssert#hasSameSizeAs(Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class StringAssert_hasSameSizeAs_with_Iterable_Test {
+
+  private Strings strings;
+  private StringAssert assertions;
+  
+  @Before
+  public void setUp() {
+	strings = mock(Strings.class);
+    assertions = new StringAssert("Yoda");
+    assertions.strings = strings;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_size() {
+	List<String> other = list("Luke");
+    assertions.hasSameSizeAs(other);
+    verify(strings).assertHasSameSizeAs(assertions.info, assertions.actual, other);
+  }
+
+  @Test public void should_return_this() {
+	StringAssert returned = assertions.hasSameSizeAs(list("Luke"));
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/BooleanArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BooleanArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.BooleanArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BooleanArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class BooleanArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static boolean[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private BooleanArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(true, false);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new BooleanArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/BooleanArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BooleanArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.BooleanArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BooleanArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class BooleanArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static boolean[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private BooleanArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(true, false);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new BooleanArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/ByteArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/ByteArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ByteArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ByteArrays#assertHasSameSizeAs(AssertionInfo, Object[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ByteArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static byte[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private ByteArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new ByteArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/ByteArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/ByteArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,80 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ByteArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ByteArrays#assertHasSameSizeAs(AssertionInfo, Object[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ByteArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static byte[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private ByteArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new ByteArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, list("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, list("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/CharArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/CharArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.CharArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link CharArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class CharArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static char[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private CharArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array('a', 'c');
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new CharArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/CharArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/CharArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.CharArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link CharArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class CharArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static char[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private CharArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array('a', 'c');
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new CharArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/DoubleArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/DoubleArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.DoubleArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link DoubleArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class DoubleArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static double[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private DoubleArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6d, 8d);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new DoubleArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/DoubleArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/DoubleArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.DoubleArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link DoubleArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class DoubleArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static double[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private DoubleArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6d, 8d);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new DoubleArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/FloatArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/FloatArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.FloatArrayFactory.array;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link FloatArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class FloatArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static float[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private FloatArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6f, 8f);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new FloatArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/FloatArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/FloatArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.FloatArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link FloatArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class FloatArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static float[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private FloatArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6f, 8f);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new FloatArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/IntArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/IntArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.IntArrayFactory.array;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link IntArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class IntArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static int[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private IntArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new IntArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/IntArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/IntArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.IntArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link IntArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class IntArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static int[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private IntArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new IntArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/LongArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/LongArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.LongArrayFactory.array;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link LongArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class LongArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static long[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private LongArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6L, 8L);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new LongArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/LongArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/LongArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.LongArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link LongArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class LongArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static long[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private LongArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6L, 8L);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new LongArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Maps_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Maps_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,76 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.MapFactory.map;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Maps#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class Maps_assertHasSameSizeAs_with_Array_Test {
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private Maps maps;
+  private Map<?, ?> actual = map(entry("name", "Yoda"), entry("job", "Yedi Master"));  
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    maps = new Maps();
+    maps.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+	 thrown.expectAssertionError(actualIsNull());
+	 maps.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      maps.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.size(), other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+
+	  maps.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Maps_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Maps_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.MapFactory.map;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Map;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Maps#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class Maps_assertHasSameSizeAs_with_Iterable_Test  {
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private Maps maps;
+  private Map<?, ?> actual = map(entry("name", "Yoda"), entry("job", "Yedi Master"));  
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    maps = new Maps();
+    maps.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+	 thrown.expectAssertionError(actualIsNull());
+	 maps.assertHasSameSizeAs(someInfo(), null, list("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      maps.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.size(), other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+	  maps.assertHasSameSizeAs(someInfo(), actual, list("Solo", "Leia"));
+  }
+
+}

--- a/src/test/java/org/fest/assertions/internal/ShortArrays_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/ShortArrays_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.ShortArrayFactory.array;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ShortArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ShortArrays_assertHasSameSizeAs_with_Array_Test {
+
+  private static short[] actual;
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private ShortArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new ShortArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/ShortArrays_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/ShortArrays_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.ShortArrayFactory.array;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link ShortArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class ShortArrays_assertHasSameSizeAs_with_Iterable_Test {
+
+  private static short[] actual;
+  private final List<String> other = list("Solo", "Leia"); 
+
+  @Rule public ExpectedException thrown = none();
+
+  private Failures failures;
+  private ShortArrays arrays;
+
+  @BeforeClass public static void setUpOnce() {
+    actual = array(6, 8);
+  }
+
+  @Before public void setUp() {
+    failures = spy(new Failures());
+    arrays = new ShortArrays();
+    arrays.failures = failures;
+  }
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    arrays.assertHasSameSizeAs(someInfo(), null, other);
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia", "Yoda");    
+    try {
+      arrays.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length, other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+    arrays.assertHasSameSizeAs(someInfo(), actual, other);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Strings_assertHasSameSizeAs_with_Array_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Strings_assertHasSameSizeAs_with_Array_Test.java
@@ -1,0 +1,56 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BooleanArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Object[])}</code>.
+ *
+ * @author Nicolas François
+ */
+public class Strings_assertHasSameSizeAs_with_Array_Test extends AbstractTest_for_Strings {
+
+  private static String actual = "Han";
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertHasSameSizeAs(someInfo(), null, array("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    String[] other = array("Solo", "Leia");    
+    try {
+    	strings.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length(), other.length));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+	  strings.assertHasSameSizeAs(someInfo(), actual, array("Solo", "Leia", "Yoda"));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Strings_assertHasSameSizeAs_with_Iterable_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Strings_assertHasSameSizeAs_with_Iterable_Test.java
@@ -1,0 +1,58 @@
+/*
+ * Created on Jun 4, 2012
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright @2010-2012 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BooleanArrays#assertHasSameSizeAs(AssertionInfo, boolean[], Iterable)}</code>.
+ *
+ * @author Nicolas François
+ */
+public class Strings_assertHasSameSizeAs_with_Iterable_Test extends AbstractTest_for_Strings {
+
+  private static String actual = "Han";
+
+  @Test public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertHasSameSizeAs(someInfo(), null, list("Solo", "Leia"));
+  }
+
+  @Test public void should_fail_if_size_of_actual_is_not_equal_to_expected_size() {
+    AssertionInfo info = someInfo();
+    List<String> other = list("Solo", "Leia");    
+    try {
+    	strings.assertHasSameSizeAs(info, actual, other);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveSameSizeAs(actual, actual.length(), other.size()));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test public void should_pass_if_size_of_actual_is_equal_to_expected_size() {
+	  strings.assertHasSameSizeAs(someInfo(), actual, list("Solo", "Leia", "Yoda"));
+  }
+}


### PR DESCRIPTION
<code>hasSameSize</code>  should be in <code>EnumerableAssert</code> not in <code>ObjectEnumerableAssert</code> to provide this method to *ArrayAssert like BooleanArrayAssert
