### PR TITLE
Github#43 - new File assertions: hasBinaryContent(byte[]), usingCharset(Charset), hasContent(String)

### DIFF
--- a/src/main/java/org/fest/assertions/api/FileAssert.java
+++ b/src/main/java/org/fest/assertions/api/FileAssert.java
@@ -119,4 +119,20 @@ public class FileAssert extends AbstractAssert<FileAssert, File> {
     files.assertEqualContent(info, actual, expected);
     return this;
   }
+
+  /**
+   * Verifies that the binary content of the actual {@code File} is equal to the given one.
+   * @param expected the expected binary content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given content is {@code null}.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws FilesException if an I/O error occurs.
+   * @throws AssertionError if the content of the actual {@code File} is not equal to the given binary content.
+   */
+  public FileAssert hasBinaryContent(byte[] expected) {
+    files.assertHasBinaryContent(info, actual, expected);
+    return this;
+  }
+  
 }

--- a/src/main/java/org/fest/assertions/api/FileAssert.java
+++ b/src/main/java/org/fest/assertions/api/FileAssert.java
@@ -15,6 +15,7 @@
 package org.fest.assertions.api;
 
 import java.io.File;
+import java.nio.charset.Charset;
 
 import org.fest.assertions.internal.Files;
 import org.fest.util.*;
@@ -28,11 +29,15 @@ import org.fest.util.*;
  * @author David DIDIER
  * @author Yvonne Wang
  * @author Alex Ruiz
+ * @author Olivier Michallat
  */
 public class FileAssert extends AbstractAssert<FileAssert, File> {
 
   @VisibleForTesting
   Files files = Files.instance();
+  
+  @VisibleForTesting
+  Charset charset = Charset.defaultCharset();
 
   protected FileAssert(File actual) {
     super(actual, FileAssert.class);
@@ -135,4 +140,46 @@ public class FileAssert extends AbstractAssert<FileAssert, File> {
     return this;
   }
   
+  /**
+   * Specifies the name of the charset to use for text-based assertions on the file's contents. 
+   * 
+   * @param charsetName the name of the charset to use.
+   * @return  {@code this} assertion object.
+   * @throws IllegalArgumentException if the given encoding is not supported on this platform.
+   */
+  public FileAssert usingCharset(String charsetName) {
+    if (!Charset.isSupported(charsetName)) throw new IllegalArgumentException(String.format("Charset:<'%s'> is not supported on this system", charsetName));
+    return usingCharset(Charset.forName(charsetName));
+  }
+
+  /**
+   * Specifies the charset to use for text-based assertions on the file's contents. 
+   * 
+   * @param charset the charset to use.
+   * @return  {@code this} assertion object.
+   * @throws NullPointerException if the given charset is {@code null}.
+   */
+  public FileAssert usingCharset(Charset charset) {
+    if (charset == null) throw new NullPointerException("The charset should not be null");
+    this.charset = charset;
+    return this;
+  }
+  
+  /**
+   * Verifies that the text content of the actual {@code File} is equal to the given one.<br/>
+   * The charset to use when reading the file should be provided with {@link #usingCharset(Charset)} or
+   * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by
+   * {@link Charset#defaultCharset()}) will be used.
+   * @param expected the expected text content to compare the actual {@code File}'s content to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given content is {@code null}.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} is not an existing file.
+   * @throws FilesException if an I/O error occurs.
+   * @throws AssertionError if the content of the actual {@code File} is not equal to the given binary content.
+   */
+  public FileAssert hasContent(String expected) {
+    files.assertHasContent(info, actual, expected, charset);
+    return this;
+  }
 }

--- a/src/main/java/org/fest/assertions/error/ShouldHaveBinaryContent.java
+++ b/src/main/java/org/fest/assertions/error/ShouldHaveBinaryContent.java
@@ -1,0 +1,42 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.error;
+
+import java.io.File;
+
+import org.fest.assertions.internal.BinaryDiffResult;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a file has a given binary content failed.
+ * 
+ * @author Olivier Michallat
+ */
+public class ShouldHaveBinaryContent extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldHaveBinaryContent}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param diff the differences between {@code actual} and the given binary content.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
+    return new ShouldHaveBinaryContent(actual, diff);
+  }
+
+  private ShouldHaveBinaryContent(File actual, BinaryDiffResult diff) {
+    super("file:<%s> does not have expected binary content: at offset <%s>, expected:\n<%s>\n but was:\n<%s>", actual,
+        diff.offset, diff.expected, diff.actual);
+  }
+}

--- a/src/main/java/org/fest/assertions/error/ShouldHaveContent.java
+++ b/src/main/java/org/fest/assertions/error/ShouldHaveContent.java
@@ -1,0 +1,53 @@
+/*
+ * Created on Jul 21, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.error;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.fest.assertions.description.Description;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that a file has a given text content failed.
+ * 
+ * @author Olivier Michallat
+ */
+public class ShouldHaveContent extends BasicErrorMessageFactory {
+
+  private String diffs;
+
+  /**
+   * Creates a new <code>{@link ShouldHaveContent}</code>.
+   * @param actual the actual file in the failed assertion.
+   * @param charset the charset that was used to read the file.
+   * @param diffs the differences between {@code actual} and the expected text that was provided in the assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveContent(File actual, Charset charset, List<String> diffs) {
+    return new ShouldHaveContent(actual, charset, ShouldHaveEqualContent.diffsAsString(diffs));
+  }
+
+  /** @see ShouldHaveEqualContent#create(Description) */
+  @Override
+  public String create(Description d) {
+    return super.create(d) + diffs;
+  }
+
+  private ShouldHaveContent(File actual, Charset charset, String diffs) {
+    super("file:<%s> read with charset:<%s> does not have expected content:", actual, charset);
+    this.diffs = diffs;
+  }
+}

--- a/src/main/java/org/fest/assertions/error/ShouldHaveEqualContent.java
+++ b/src/main/java/org/fest/assertions/error/ShouldHaveEqualContent.java
@@ -72,7 +72,7 @@ public class ShouldHaveEqualContent extends BasicErrorMessageFactory {
     return super.create(d) + diffs;
   }
 
-  private static String diffsAsString(List<String> diffs) {
+  static String diffsAsString(List<String> diffs) {
     StringBuilder b = new StringBuilder();
     for (String diff : diffs)
       b.append(LINE_SEPARATOR).append(diff);

--- a/src/main/java/org/fest/assertions/internal/BinaryDiff.java
+++ b/src/main/java/org/fest/assertions/internal/BinaryDiff.java
@@ -14,8 +14,6 @@
  */
 package org.fest.assertions.internal;
 
-import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -55,7 +53,7 @@ class BinaryDiff {
     while (true) {
       int actual = actualStream.read();
       int expected = expectedStream.read();
-      if (actual == -1 && expected == -1) return SUCCESS; // reached end of both streams
+      if (actual == -1 && expected == -1) return BinaryDiffResult.noDiff(); // reached end of both streams
       if (actual != expected) return new BinaryDiffResult(index, expected, actual);
       index += 1;
     }

--- a/src/main/java/org/fest/assertions/internal/BinaryDiff.java
+++ b/src/main/java/org/fest/assertions/internal/BinaryDiff.java
@@ -1,0 +1,63 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2008-2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.fest.util.VisibleForTesting;
+
+/**
+ * Compares the binary content of two streams.
+ * 
+ * @author Olivier Michallat
+ */
+class BinaryDiff {
+  BinaryDiffResult diff(File actual, byte[] expected) throws IOException {
+    InputStream expectedStream = new ByteArrayInputStream(expected);
+    InputStream actualStream = null;
+    boolean threw = true;
+    try {
+      actualStream = new FileInputStream(actual);
+      BinaryDiffResult result = diff(actualStream, expectedStream);
+      threw = false;
+      return result;
+    } finally {
+      try {
+        if (actualStream != null) actualStream.close();
+      } catch (IOException e) {
+        // Only rethrow if it doesn't shadow an exception thrown from the inner try block
+        if (!threw) throw e;
+      }
+    }
+  }
+
+  @VisibleForTesting
+  BinaryDiffResult diff(InputStream actualStream, InputStream expectedStream) throws IOException {
+    int index = 0;
+    while (true) {
+      int actual = actualStream.read();
+      int expected = expectedStream.read();
+      if (actual == -1 && expected == -1) return SUCCESS; // reached end of both streams
+      if (actual != expected) return new BinaryDiffResult(index, expected, actual);
+      index += 1;
+    }
+  }
+}

--- a/src/main/java/org/fest/assertions/internal/BinaryDiffResult.java
+++ b/src/main/java/org/fest/assertions/internal/BinaryDiffResult.java
@@ -20,8 +20,8 @@ package org.fest.assertions.internal;
  * @author Olivier Michallat
  */
 public class BinaryDiffResult {
-  public static final BinaryDiffResult SUCCESS = new BinaryDiffResult(-1, (byte) 0, (byte) 0);
-  
+  private static final int EOF = -1;
+
   public final int offset;
   public final String expected;
   public final String actual;
@@ -30,16 +30,24 @@ public class BinaryDiffResult {
    * Builds a new instance.
    * 
    * @param offset the offset at which the difference occurred.
-   * @param expected the expected byte as an int in the range 0 to 255, or -1 for EOF
-   * @param actual the actual byte in the same format
+   * @param expected the expected byte as an int in the range 0 to 255, or -1 for EOF.
+   * @param actual the actual byte in the same format.
    */
   public BinaryDiffResult(int offset, int expected, int actual) {
     this.offset = offset;
     this.expected = describe(expected);
     this.actual = describe(actual);
   }
+  
+  public boolean hasNoDiff() {
+    return offset == EOF;
+  }
+  
+  public static BinaryDiffResult noDiff() {
+    return new BinaryDiffResult(EOF, 0, 0);
+  }
 
   private String describe(int b) {
-    return (b == -1) ? "EOF" : "0x" + Integer.toHexString(b).toUpperCase();
+    return (b == EOF) ? "EOF" : "0x" + Integer.toHexString(b).toUpperCase();
   }
 }

--- a/src/main/java/org/fest/assertions/internal/BinaryDiffResult.java
+++ b/src/main/java/org/fest/assertions/internal/BinaryDiffResult.java
@@ -1,0 +1,45 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2008-2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+/**
+ * Value class to hold the result of comparing two binary streams.
+ * 
+ * @author Olivier Michallat
+ */
+public class BinaryDiffResult {
+  public static final BinaryDiffResult SUCCESS = new BinaryDiffResult(-1, (byte) 0, (byte) 0);
+  
+  public final int offset;
+  public final String expected;
+  public final String actual;
+  
+  /**
+   * Builds a new instance.
+   * 
+   * @param offset the offset at which the difference occurred.
+   * @param expected the expected byte as an int in the range 0 to 255, or -1 for EOF
+   * @param actual the actual byte in the same format
+   */
+  public BinaryDiffResult(int offset, int expected, int actual) {
+    this.offset = offset;
+    this.expected = describe(expected);
+    this.actual = describe(actual);
+  }
+
+  private String describe(int b) {
+    return (b == -1) ? "EOF" : "0x" + Integer.toHexString(b).toUpperCase();
+  }
+}

--- a/src/main/java/org/fest/assertions/internal/Files.java
+++ b/src/main/java/org/fest/assertions/internal/Files.java
@@ -23,7 +23,6 @@ import static org.fest.assertions.error.ShouldHaveBinaryContent.shouldHaveBinary
 import static org.fest.assertions.error.ShouldHaveContent.shouldHaveContent;
 import static org.fest.assertions.error.ShouldHaveEqualContent.shouldHaveEqualContent;
 import static org.fest.assertions.error.ShouldNotExist.shouldNotExist;
-import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
 
 import java.io.File;
 import java.io.IOException;
@@ -106,7 +105,7 @@ public class Files {
     assertIsFile(info, actual);
     try {
       BinaryDiffResult result = binaryDiff.diff(actual, expected);
-      if (result == SUCCESS) return;
+      if (result.hasNoDiff()) return;
       throw failures.failure(info, shouldHaveBinaryContent(actual, result));
     } catch (IOException e) {
       String msg = String.format("Unable to verify binary contents of file:<%s>", actual);

--- a/src/main/java/org/fest/assertions/internal/Files.java
+++ b/src/main/java/org/fest/assertions/internal/Files.java
@@ -20,15 +20,19 @@ import static org.fest.assertions.error.ShouldBeFile.shouldBeFile;
 import static org.fest.assertions.error.ShouldBeRelativePath.shouldBeRelativePath;
 import static org.fest.assertions.error.ShouldExist.shouldExist;
 import static org.fest.assertions.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
+import static org.fest.assertions.error.ShouldHaveContent.shouldHaveContent;
 import static org.fest.assertions.error.ShouldHaveEqualContent.shouldHaveEqualContent;
 import static org.fest.assertions.error.ShouldNotExist.shouldNotExist;
 import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 
 import org.fest.assertions.core.AssertionInfo;
-import org.fest.util.*;
+import org.fest.util.FilesException;
+import org.fest.util.VisibleForTesting;
 
 /**
  * Reusable assertions for <code>{@link File}</code>s.
@@ -85,7 +89,7 @@ public class Files {
       throw new FilesException(msg, e);
     }
   }
-  
+
   /**
    * Asserts that the given file has the given binary content.
    * @param info contains information about the assertion.
@@ -110,6 +114,30 @@ public class Files {
     }
   }
 
+  /**
+   * Asserts that the given file has the given text content.
+   * @param info contains information about the assertion.
+   * @param actual the "actual" file.
+   * @param expected the "expected" text content.
+   * @param charset the charset to use to read the file.
+   * @throws NullPointerException if {@code expected} is {@code null}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if {@code actual} is not an existing file.
+   * @throws FilesException if an I/O error occurs.
+   * @throws AssertionError if the file does not have the text content.
+   */
+  public void assertHasContent(AssertionInfo info, File actual, String expected, Charset charset) {
+    if (expected == null) throw new NullPointerException("The text to compare to should not be null");
+    assertIsFile(info, actual);
+    try {
+      List<String> diffs = diff.diff(actual, expected, charset);
+      if (diffs.isEmpty()) return;
+      throw failures.failure(info, shouldHaveContent(actual, charset, diffs));
+    } catch (IOException e) {
+      String msg = String.format("Unable to verify text contents of file:<%s>", actual);
+      throw new FilesException(msg, e);
+    }
+  }
 
   private void verifyIsFile(File expected) {
     if (expected == null) throw new NullPointerException("The file to compare to should not be null");

--- a/src/test/java/org/fest/assertions/api/FileAssert_hasBinaryContent_Test.java
+++ b/src/test/java/org/fest/assertions/api/FileAssert_hasBinaryContent_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+
+import org.fest.assertions.internal.Files;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link FileAssert#hasBinaryContent(byte[])}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class FileAssert_hasBinaryContent_Test {
+
+  private Files files;
+  private FileAssert assertions;
+  private byte[] content = new byte[0];
+  
+
+  @Before
+  public void setUp() {
+    files = mock(Files.class);
+    assertions = new FileAssert(new File("abc"));
+    assertions.files = files;
+  }
+
+  @Test
+  public void should_verify_that_actual_has_expected_binary_content() {
+    assertions.hasBinaryContent(content);
+    verify(files).assertHasBinaryContent(assertions.info, assertions.actual, content);
+  }
+
+  @Test
+  public void should_return_this() {
+    FileAssert returned = assertions.hasBinaryContent(content);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/FileAssert_hasContent_Test.java
+++ b/src/test/java/org/fest/assertions/api/FileAssert_hasContent_Test.java
@@ -1,0 +1,60 @@
+/*
+ * Created on Jul 21, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+
+import org.fest.assertions.internal.Files;
+import org.junit.*;
+
+/**
+ * Tests for <code>{@link FileAssert#hasContent(String)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class FileAssert_hasContent_Test {
+
+  private static String expected;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    expected = "xyz";
+  }
+
+  private Files files;
+  private FileAssert assertions;
+
+  @Before
+  public void setUp() {
+    files = mock(Files.class);
+    assertions = new FileAssert(new File("abc"));
+    assertions.files = files;
+  }
+
+  @Test
+  public void should_verify_that_content_in_actual_is_equal_to_expected() {
+    assertions.hasContent(expected);
+    verify(files).assertHasContent(assertions.info, assertions.actual, expected, assertions.charset);
+  }
+
+  @Test
+  public void should_return_this() {
+    FileAssert returned = assertions.hasContent(expected);
+    assertSame(assertions, returned);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/FileAssert_usingCharset_Test.java
+++ b/src/test/java/org/fest/assertions/api/FileAssert_usingCharset_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Created on Jul 21, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.nio.charset.Charset;
+
+import org.fest.assertions.test.ExpectedException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link FileAssert#usingCharset(String)}</code> and <code>{@link FileAssert#usingCharset(Charset)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class FileAssert_usingCharset_Test {
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  private FileAssert assertions;
+  private Charset defaultCharset;
+  private Charset otherCharset;
+
+  @Before
+  public void setUp() {
+    assertions = new FileAssert(new File("abc"));
+    defaultCharset = Charset.defaultCharset();
+    for (Charset charset : Charset.availableCharsets().values()) {
+      if (!charset.equals(defaultCharset)) otherCharset = charset;
+    }
+  }
+
+  @Test
+  public void should_use_default_charset_if_none_provided() {
+    assertEquals(defaultCharset, assertions.charset);
+  }
+
+  @Test
+  public void should_use_provided_charset() {
+    assertions.usingCharset(otherCharset);
+    assertEquals(otherCharset, assertions.charset);
+  }
+  
+  @Test
+  public void should_use_provided_charset_name() {
+    assertions.usingCharset(otherCharset.name());
+    assertEquals(otherCharset, assertions.charset);
+  }
+  
+  @Test
+  public void should_throw_exception_for_null_charset() {
+    thrown.expectNullPointerException("The charset should not be null");
+    assertions.usingCharset((Charset) null);
+  }
+
+  @Test
+  public void should_throw_exception_for_invalid_charset_name() {
+    thrown.expectIllegalArgumentException("Charset:<'Klingon'> is not supported on this system");
+    assertions.usingCharset("Klingon");
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
@@ -1,0 +1,97 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static junit.framework.Assert.assertEquals;
+import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
+import static org.junit.Assert.assertSame;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.fest.assertions.test.TextFileWriter;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for <code>{@link BinaryDiff#diff(java.io.File, byte[])}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class BinaryDiff_diff_File_byteArray_Test {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private static BinaryDiff binaryDiff;
+  private static TextFileWriter writer;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    binaryDiff = new BinaryDiff();
+    writer = TextFileWriter.instance();
+  }
+
+  private File actual;
+  private byte[] expected;
+
+  @Before
+  public void setUp() throws IOException {
+    actual = folder.newFile("actual.txt");
+  }
+
+  @Test
+  public void should_return_success_if_file_and_array_have_equal_content() throws IOException {
+    writer.write(actual, "test");
+    // Note: writer inserts a \n after each line so we need it in our expected content
+    expected = "test\n".getBytes(Charset.defaultCharset());
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertSame(SUCCESS, result);
+  }
+  
+  @Test
+  public void should_return_diff_if_inputstreams_differ_on_one_byte() throws IOException {
+    writer.write(actual, "test");
+    expected = "fest\n".getBytes(Charset.defaultCharset());
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(0, result.offset);
+    assertEquals("0x74", result.actual);
+    assertEquals("0x66", result.expected);
+  }
+  
+  @Test
+  public void should_return_diff_if_actual_is_shorter() throws IOException {
+    writer.write(actual, "foo");
+    expected = "foo\nbar".getBytes(Charset.defaultCharset());
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(4, result.offset);
+    assertEquals("EOF", result.actual);
+    assertEquals("0x62", result.expected);
+  }
+  
+  @Test
+  public void should_return_diff_if_expected_is_shorter() throws IOException {
+    writer.write(actual, "foobar");
+    expected = "foo".getBytes(Charset.defaultCharset());
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(3, result.offset);
+    assertEquals("0x62", result.actual);
+    assertEquals("EOF", result.expected);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.assertSame;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 
 import org.fest.assertions.test.TextFileWriter;
 import org.junit.Before;
@@ -60,7 +59,7 @@ public class BinaryDiff_diff_File_byteArray_Test {
   public void should_return_success_if_file_and_array_have_equal_content() throws IOException {
     writer.write(actual, "test");
     // Note: writer inserts a \n after each line so we need it in our expected content
-    expected = "test\n".getBytes(Charset.defaultCharset());
+    expected = "test\n".getBytes();
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
     assertSame(SUCCESS, result);
   }
@@ -68,7 +67,7 @@ public class BinaryDiff_diff_File_byteArray_Test {
   @Test
   public void should_return_diff_if_inputstreams_differ_on_one_byte() throws IOException {
     writer.write(actual, "test");
-    expected = "fest\n".getBytes(Charset.defaultCharset());
+    expected = "fest\n".getBytes();
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
     assertEquals(0, result.offset);
     assertEquals("0x74", result.actual);
@@ -78,7 +77,7 @@ public class BinaryDiff_diff_File_byteArray_Test {
   @Test
   public void should_return_diff_if_actual_is_shorter() throws IOException {
     writer.write(actual, "foo");
-    expected = "foo\nbar".getBytes(Charset.defaultCharset());
+    expected = "foo\nbar".getBytes();
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
     assertEquals(4, result.offset);
     assertEquals("EOF", result.actual);
@@ -88,7 +87,7 @@ public class BinaryDiff_diff_File_byteArray_Test {
   @Test
   public void should_return_diff_if_expected_is_shorter() throws IOException {
     writer.write(actual, "foobar");
-    expected = "foo".getBytes(Charset.defaultCharset());
+    expected = "foo".getBytes();
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
     assertEquals(3, result.offset);
     assertEquals("0x62", result.actual);

--- a/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_File_byteArray_Test.java
@@ -15,8 +15,7 @@
 package org.fest.assertions.internal;
 
 import static junit.framework.Assert.assertEquals;
-import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,12 +55,12 @@ public class BinaryDiff_diff_File_byteArray_Test {
   }
 
   @Test
-  public void should_return_success_if_file_and_array_have_equal_content() throws IOException {
+  public void should_return_no_diff_if_file_and_array_have_equal_content() throws IOException {
     writer.write(actual, "test");
     // Note: writer inserts a \n after each line so we need it in our expected content
     expected = "test\n".getBytes();
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
-    assertSame(SUCCESS, result);
+    assertTrue(result.hasNoDiff());
   }
   
   @Test

--- a/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_InputStream_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_InputStream_Test.java
@@ -15,8 +15,7 @@
 package org.fest.assertions.internal;
 
 import static junit.framework.Assert.assertEquals;
-import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
-import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -43,11 +42,11 @@ public class BinaryDiff_diff_InputStream_Test {
   private InputStream expected;
 
   @Test
-  public void should_return_success_if_inputstreams_have_equal_content() throws IOException {
+  public void should_return_no_diff_if_inputstreams_have_equal_content() throws IOException {
     actual = stream(0xCA, 0xFE, 0xBA, 0xBE);
     expected = stream(0xCA, 0xFE, 0xBA, 0xBE);
     BinaryDiffResult result = binaryDiff.diff(actual, expected);
-    assertSame(SUCCESS, result);
+    assertTrue(result.hasNoDiff());
   }
   
   @Test

--- a/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_InputStream_Test.java
+++ b/src/test/java/org/fest/assertions/internal/BinaryDiff_diff_InputStream_Test.java
@@ -1,0 +1,90 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static junit.framework.Assert.assertEquals;
+import static org.fest.assertions.internal.BinaryDiffResult.SUCCESS;
+import static org.junit.Assert.assertSame;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link BinaryDiff#diff(java.io.InputStream, java.io.InputStream)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class BinaryDiff_diff_InputStream_Test {
+
+  private static BinaryDiff binaryDiff;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    binaryDiff = new BinaryDiff();
+  }
+
+  private InputStream actual;
+  private InputStream expected;
+
+  @Test
+  public void should_return_success_if_inputstreams_have_equal_content() throws IOException {
+    actual = stream(0xCA, 0xFE, 0xBA, 0xBE);
+    expected = stream(0xCA, 0xFE, 0xBA, 0xBE);
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertSame(SUCCESS, result);
+  }
+  
+  @Test
+  public void should_return_diff_if_inputstreams_differ_on_one_byte() throws IOException {
+    actual = stream(0xCA, 0xFE, 0xBA, 0xBE);
+    expected = stream(0xCA, 0xFE, 0xBE, 0xBE);
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(2, result.offset);
+    assertEquals("0xBA", result.actual);
+    assertEquals("0xBE", result.expected);
+  }
+  
+  @Test
+  public void should_return_diff_if_actual_is_shorter() throws IOException {
+    actual = stream(0xCA, 0xFE, 0xBA);
+    expected = stream(0xCA, 0xFE, 0xBA, 0xBE);
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(3, result.offset);
+    assertEquals("EOF", result.actual);
+    assertEquals("0xBE", result.expected);
+  }
+  
+  @Test
+  public void should_return_diff_if_expected_is_shorter() throws IOException {
+    actual = stream(0xCA, 0xFE, 0xBA, 0xBE);
+    expected = stream(0xCA, 0xFE, 0xBA);
+    BinaryDiffResult result = binaryDiff.diff(actual, expected);
+    assertEquals(3, result.offset);
+    assertEquals("0xBE", result.actual);
+    assertEquals("EOF", result.expected);
+  }
+
+  private InputStream stream(int... contents) {
+    byte[] byteContents = new byte[contents.length];
+    for (int i = 0; i < contents.length; i++) {
+      byteContents[i] = (byte) contents[i];
+    }
+    return new ByteArrayInputStream(byteContents);
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Diff_diff_File_String_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Diff_diff_File_String_Test.java
@@ -1,0 +1,96 @@
+/*
+ * Created on Jul 21, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static junit.framework.Assert.assertEquals;
+import static org.fest.util.Arrays.array;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import org.fest.assertions.test.TextFileWriter;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Tests for <code>{@link Diff#diff(File, String, java.nio.charset.Charset)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class Diff_diff_File_String_Test {
+  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private static Diff diff;
+  private static TextFileWriter writer;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    diff = new Diff();
+    writer = TextFileWriter.instance();
+  }
+
+  private File actual;
+
+  @Before
+  public void setUp() throws IOException {
+    actual = folder.newFile("actual.txt");
+  }
+
+  @Test
+  public void should_return_empty_diff_list_if_file_and_string_have_equal_content() throws IOException {
+    String[] content = array("line0", "line1");
+    writer.write(actual, content);
+    String expected = "line0\nline1";
+    List<String> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    assertEquals(0, diffs.size());
+  }
+
+  @Test
+  public void should_return_diffs_if_file_and_string_do_not_have_equal_content() throws IOException {
+    writer.write(actual, UTF8, "Touché");
+    String expected = "Touché";
+    List<String> diffs = diff.diff(actual, expected, ISO_8859_1);
+    assertEquals(1, diffs.size());
+    assertEquals("line:<0>, expected:<Touché> but was:<TouchÃ©>", diffs.get(0));
+  }
+
+  @Test
+  public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
+    writer.write(actual, "line_0");
+    String expected = "line_0\nline_1";
+    List<String> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    System.out.println(diffs);
+    assertEquals(1, diffs.size());
+    assertEquals("line:<1>, expected:<line_1> but was:<EOF>", diffs.get(0));
+  }
+
+  @Test
+  public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
+    writer.write(actual, "line_0", "line_1");
+    String expected = "line_0";
+    List<String> diffs = diff.diff(actual, expected, Charset.defaultCharset());
+    assertEquals(1, diffs.size());
+    assertEquals("line:<1>, expected:<EOF> but was:<line_1>", diffs.get(0));
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Files_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Files_assertHasBinaryContent_Test.java
@@ -1,0 +1,130 @@
+/*
+ * Created on Jul 20, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.fail;
+import static org.fest.assertions.error.ShouldBeFile.shouldBeFile;
+import static org.fest.assertions.error.ShouldHaveBinaryContent.shouldHaveBinaryContent;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.fest.util.FilesException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Files#assertHasBinaryContent(org.fest.assertions.core.WritableAssertionInfo, File, byte[])}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class Files_assertHasBinaryContent_Test {
+
+  private static File actual;
+  private static byte[] expected;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    // Does not matter if the values differ, the actual comparison is mocked in this test
+    actual = new File("src/test/resources/actual_file.txt");
+    expected = new byte[] {};
+  }
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  private BinaryDiff binaryDiff;
+  private Failures failures;
+  private Files files;
+
+  @Before
+  public void setUp() {
+    binaryDiff = mock(BinaryDiff.class);
+    failures = spy(new Failures());
+    files = new Files();
+    files.binaryDiff = binaryDiff;
+    files.failures = failures;
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+    thrown.expectNullPointerException("The binary content to compare to should not be null");
+    files.assertHasBinaryContent(someInfo(), actual, null);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    files.assertHasBinaryContent(someInfo(), null, expected);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_file() {
+    AssertionInfo info = someInfo();
+    File notAFile = new File("xyz");
+    try {
+      files.assertHasBinaryContent(info, notAFile, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldBeFile(notAFile));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_file_has_expected_binary_content() throws IOException {
+    when(binaryDiff.diff(actual, expected)).thenReturn(BinaryDiffResult.SUCCESS);
+    files.assertHasBinaryContent(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    IOException cause = new IOException();
+    when(binaryDiff.diff(actual, expected)).thenThrow(cause);
+    try {
+      files.assertHasBinaryContent(someInfo(), actual, expected);
+      fail("Expected a FilesException to be thrown");
+    } catch (FilesException e) {
+      assertSame(cause, e.getCause());
+    }
+  }
+
+  @Test
+  public void should_fail_if_file_does_not_have_expected_binary_content() throws IOException {
+    BinaryDiffResult diff = new BinaryDiffResult(15, (byte) 0xCA, (byte) 0xFE);
+    when(binaryDiff.diff(actual, expected)).thenReturn(diff);
+    AssertionInfo info = someInfo();
+    try {
+      files.assertHasBinaryContent(info, actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveBinaryContent(actual, diff));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/fest/assertions/internal/Files_assertHasBinaryContent_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Files_assertHasBinaryContent_Test.java
@@ -98,7 +98,7 @@ public class Files_assertHasBinaryContent_Test {
 
   @Test
   public void should_pass_if_file_has_expected_binary_content() throws IOException {
-    when(binaryDiff.diff(actual, expected)).thenReturn(BinaryDiffResult.SUCCESS);
+    when(binaryDiff.diff(actual, expected)).thenReturn(BinaryDiffResult.noDiff());
     files.assertHasBinaryContent(someInfo(), actual, expected);
   }
 

--- a/src/test/java/org/fest/assertions/internal/Files_assertHasContent_Test.java
+++ b/src/test/java/org/fest/assertions/internal/Files_assertHasContent_Test.java
@@ -1,0 +1,136 @@
+/*
+ * Created on Jul 21, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.internal;
+
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.fail;
+import static org.fest.assertions.error.ShouldBeFile.shouldBeFile;
+import static org.fest.assertions.error.ShouldHaveContent.shouldHaveContent;
+import static org.fest.assertions.test.ExpectedException.none;
+import static org.fest.assertions.test.FailureMessages.actualIsNull;
+import static org.fest.assertions.test.TestData.someInfo;
+import static org.fest.assertions.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.fest.util.Collections.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.fest.assertions.core.AssertionInfo;
+import org.fest.assertions.test.ExpectedException;
+import org.fest.util.FilesException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Files#assertHasContent(AssertionInfo, File, String, Charset)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class Files_assertHasContent_Test {
+
+  private static File actual;
+  private static String expected;
+  private static Charset charset;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    // Does not matter if the values differ, the actual comparison is mocked in this test
+    actual = new File("src/test/resources/actual_file.txt");
+    expected = "xyz";
+    charset = Charset.defaultCharset();
+  }
+
+  @Rule
+  public ExpectedException thrown = none();
+
+  private Diff diff;
+  private Failures failures;
+  private Files files;
+
+  @Before
+  public void setUp() {
+    diff = mock(Diff.class);
+    failures = spy(new Failures());
+    files = new Files();
+    files.diff = diff;
+    files.failures = failures;
+  }
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+    thrown.expectNullPointerException("The text to compare to should not be null");
+    files.assertHasContent(someInfo(), actual, null, charset);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    files.assertHasContent(someInfo(), null, expected, charset);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_not_file() {
+    AssertionInfo info = someInfo();
+    File notAFile = new File("xyz");
+    try {
+      files.assertHasContent(info, notAFile, expected, charset);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldBeFile(notAFile));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+
+  @Test
+  public void should_pass_if_file_has_text_content() throws IOException {
+    when(diff.diff(actual, expected, charset)).thenReturn(new ArrayList<String>());
+    files.assertHasContent(someInfo(), actual, expected, charset);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    IOException cause = new IOException();
+    when(diff.diff(actual, expected, charset)).thenThrow(cause);
+    try {
+      files.assertHasContent(someInfo(), actual, expected, charset);
+      fail("Expected a FilesException to be thrown");
+    } catch (FilesException e) {
+      assertSame(cause, e.getCause());
+    }
+  }
+
+  @Test
+  public void should_fail_if_file_does_not_have_expected_text_content() throws IOException {
+    List<String> diffs = list("line:1, expected:<line1> but was:<EOF>");
+    when(diff.diff(actual, expected, charset)).thenReturn(diffs);
+    AssertionInfo info = someInfo();
+    try {
+      files.assertHasContent(info, actual, expected, charset);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveContent(actual, charset, diffs));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}

--- a/src/test/java/org/fest/assertions/test/TextFileWriter.java
+++ b/src/test/java/org/fest/assertions/test/TextFileWriter.java
@@ -17,10 +17,16 @@ package org.fest.assertions.test;
 import static org.fest.util.Closeables.close;
 import static org.fest.util.Flushables.flush;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
 
 /**
  * @author Yvonne Wang
+ * @author Olivier Michallat
  */
 public class TextFileWriter {
 
@@ -31,9 +37,13 @@ public class TextFileWriter {
   }
 
   public void write(File file, String... content) throws IOException {
+    write(file, Charset.defaultCharset(), content);
+  }
+
+  public void write(File file, Charset charset, String... content) throws IOException {
     PrintWriter writer = null;
     try {
-      writer = new PrintWriter(new FileWriter(file));
+      writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), charset));
       for (String line : content)
         writer.println(line);
     } finally {
@@ -41,6 +51,6 @@ public class TextFileWriter {
       close(writer);
     }
   }
-
+  
   private TextFileWriter() {}
 }


### PR DESCRIPTION
The binary assertion reports the first different byte (offset, expected and actual).
The text assertion delegates to the existing `Diff` class (therefore reporting all different lines).

Notes:
- the new error class `ShouldHaveContent` is very similar to `ShouldHaveEqualContent` (I've made a method of the latter package-private to reuse it), but somehow it didn't feel right to use the same class for everything.
- the existing `FileAssert.hasContentEqualTo(File)` should probably use a charset too, at least to display lines correctly when reporting an error.
- `Diff` used `reader.ready()` to test if there were more lines. According to the Javadoc, the method returns "True if the next read() is guaranteed not to block for input, false otherwise". This seems to work with files, but not with `StringReader`. This has led me to refactor `Diff.diff` to use the test `readLine() != null`. I've also switched to using `BufferedReader`s and maintaining the line number in the code, because the reader is now past the line by the time we report an error.
