### PR TITLE
github #58 - Properties: add ofType() method to improve API fluency

### DIFF
--- a/src/main/java/org/fest/assertions/groups/Properties.java
+++ b/src/main/java/org/fest/assertions/groups/Properties.java
@@ -28,6 +28,7 @@ import org.fest.util.VisibleForTesting;
  * @author Mikhail Mazursky
  * @author Joel Costigliola
  * @author Florent Biville
+ * @author Olivier Michallat
  */
 public class Properties<T> {
 
@@ -63,7 +64,7 @@ public class Properties<T> {
   public static Properties<Object> extractProperty(String propertyName) {
     return extractProperty(propertyName, Object.class);
   }
-
+  
   private static void checkIsNotNullOrEmpty(String propertyName) {
     if (propertyName == null) throw new NullPointerException("The name of the property to read should not be null");
     if (propertyName.length() == 0) throw new IllegalArgumentException("The name of the property to read should not be empty");
@@ -75,6 +76,25 @@ public class Properties<T> {
     this.propertyType = propertyType;
   }
 
+  /**
+   * Specifies the target type of an instance that was previously created with {@link #extractProperty(String)}.
+   * <p>
+   * This is so that you can write:
+   * <pre>
+   * extractProperty("name").ofType(String.class).from(fellowshipOfTheRing)
+   * </pre>
+   * instead of:
+   * <pre>
+   * extractProperty("name", String.class).from(fellowshipOfTheRing)
+   * </pre>
+   * </p>
+   * @param propertyType the type of property to extract.
+   * @return a new {@code Properties} with the given type.
+   */
+  public <U> Properties<U> ofType(Class<U> propertyType) {
+    return extractProperty(this.propertyName, propertyType);
+  }
+  
   /**
    * Extracts the values of the property (specified previously in <code>{@link #extractProperty(String)}</code>) from the elements
    * of the given <code>{@link Iterable}</code>.

--- a/src/test/java/org/fest/assertions/groups/Properties_ofType_Test.java
+++ b/src/test/java/org/fest/assertions/groups/Properties_ofType_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Created on Jul 27, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.fest.assertions.groups;
+
+import static junit.framework.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Properties#ofType(Class)}</code>.
+ * 
+ * @author Olivier Michallat
+ */
+public class Properties_ofType_Test {
+
+  @Test
+  public void should_create_a_new_Properties() {
+    Properties<String> properties = Properties.extractProperty("id").ofType(String.class);
+    assertEquals("id", properties.propertyName);
+    assertEquals(String.class, properties.propertyType);
+  }
+}


### PR DESCRIPTION
`ofType()` builds a new `Properties` instance in order to get the proper type parameter. This means we throw away the previous instance, but I don't think this is really a problem.
