### PR TITLE
Add convenience methods for MapEntry assertions

### DIFF
--- a/src/main/java/org/fest/assertions/api/MapAssert.java
+++ b/src/main/java/org/fest/assertions/api/MapAssert.java
@@ -151,6 +151,30 @@ public class MapAssert<K, V> extends AbstractAssert<MapAssert<K, V>, Map<K, V>> 
     return this;
   }
 
+  /**
+   * Verifies that the actual map contains an entry with the given key/value pair.
+   * @param key of the entry that should be in actual map.
+   * @param value of the entry that should be in actual map.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map does not contain an entry with the given key/value pair.
+   */
+  public MapAssert<K, V> containsEntry(K key, V value) {
+    maps.assertContains(info, actual, new MapEntry[]{ MapEntry.entry(key, value)});
+    return this;
+  }
+
+  /**
+   * Verifies that the actual map does not contain an entry with the given key/value pair.
+   * @param key of the entry that should not be in actual map.
+   * @param value of the entry that should not be in actual map.
+   * @throws AssertionError if the actual map is {@code null}.
+   * @throws AssertionError if the actual map contains an entry with the given key/value pair.
+   */
+  public MapAssert<K, V> doesNotContainEntry(K key, V value) {
+    maps.assertDoesNotContain(info, actual, new MapEntry[]{ MapEntry.entry(key, value)});
+    return this;
+  }
+
   /** {@inheritDoc} */
   public MapAssert<K, V> usingElementComparator(Comparator<? super MapEntry> customComparator) {
     throw new UnsupportedOperationException("custom element Comparator is not supported for MapEntry comparison");

--- a/src/test/java/org/fest/assertions/api/map/MapAssert_containsEntry_Test.java
+++ b/src/test/java/org/fest/assertions/api/map/MapAssert_containsEntry_Test.java
@@ -1,0 +1,29 @@
+package org.fest.assertions.api.map;
+
+import org.fest.assertions.api.MapAssert;
+import org.fest.assertions.api.MapAssertBaseTest;
+import org.fest.assertions.data.MapEntry;
+
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link MapAssert#containsEntry(Object, Object)}}</code>.
+ *
+ * @author Sam Beran
+ */
+public class MapAssert_containsEntry_Test extends MapAssertBaseTest {
+
+  final MapEntry[] entries = array(entry("key1", "value1"));
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.containsEntry("key1", "value1");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertContains(getInfo(assertions), getActual(assertions), entries);
+  }
+}

--- a/src/test/java/org/fest/assertions/api/map/MapAssert_doesNotContainEntry_Test.java
+++ b/src/test/java/org/fest/assertions/api/map/MapAssert_doesNotContainEntry_Test.java
@@ -1,0 +1,30 @@
+package org.fest.assertions.api.map;
+
+
+import org.fest.assertions.api.MapAssert;
+import org.fest.assertions.api.MapAssertBaseTest;
+import org.fest.assertions.data.MapEntry;
+
+import static org.fest.assertions.data.MapEntry.entry;
+import static org.fest.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link org.fest.assertions.api.MapAssert#doesNotContainEntry(Object, Object)}}</code>.
+ *
+ * @author Sam Beran
+ */
+public class MapAssert_doesNotContainEntry_Test extends MapAssertBaseTest {
+
+  final MapEntry[] entries = array(entry("key1", "value1"));
+
+  @Override
+  protected MapAssert<Object, Object> invoke_api_method() {
+    return assertions.doesNotContainEntry("key1", "value1");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(maps).assertDoesNotContain(getInfo(assertions), getActual(assertions), entries);
+  }
+}


### PR DESCRIPTION
Quite often, I find myself testing map entries in the following way:

```
Map<String, String> address = ....
assertThat(address)
                .hasSize(15)
                .includes(
                        MapAssert.entry("zip", "43865"),
                        MapAssert.entry("lastName", "Frazier"),
                        MapAssert.entry("state", "IA"),
                        MapAssert.entry("city", "Culloden")
                );
```

This change allows me to simplify the map assertions by getting rid of the repeated MapAssert.entry calls:

```
Map<String, String> address = ....
assertThat(address)
                .hasSize(15)
                .includesEntry("zip", "43865")
                .includesEntry("lastName", "Frazier")
                .includesEntry("state", "IA")
                .includesEntry("city", "Culloden");
```

Please let me know if there's anything I can do to clean up the request!

Thanks for all your work on FEST! Assert and Reflect are life savers!
Sam
