### PR TITLE
assertThat() should accept an Iterator 

### DIFF
--- a/src/main/java/org/fest/assertions/api/Assertions.java
+++ b/src/main/java/org/fest/assertions/api/Assertions.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -58,6 +59,7 @@ import org.fest.util.FilesException;
  * @author Matthieu Baechler
  * @author Mikhail Mazursky
  * @author Nicolas François
+ * @author Julien Meddah
  */
 public class Assertions {
 
@@ -157,6 +159,16 @@ public class Assertions {
    * @return the created assertion object.
    */
   public static <T> IterableAssert<T> assertThat(Iterable<T> actual) {
+    return new IterableAssert<T>(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link IterableAssert}</code>.
+   * The <code>{@link Iterator}</code> is first converted into an <code>{@link Iterable}</code>
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static <T> IterableAssert<T> assertThat(Iterator<T> actual) {
     return new IterableAssert<T>(actual);
   }
 

--- a/src/main/java/org/fest/assertions/api/IterableAssert.java
+++ b/src/main/java/org/fest/assertions/api/IterableAssert.java
@@ -14,6 +14,11 @@
  */
 package org.fest.assertions.api;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+
+
 /**
  * Assertion methods for {@link Iterable}.
  * <p>
@@ -26,10 +31,23 @@ package org.fest.assertions.api;
  * @author Matthieu Baechler
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Julien Meddah
  */
 public class IterableAssert<T> extends AbstractIterableAssert<IterableAssert<T>, Iterable<T>, T> {
 
   protected IterableAssert(Iterable<T> actual) {
     super(actual, IterableAssert.class);
+  }
+  
+  protected IterableAssert(Iterator<T> actual) {
+    this(toIterable(actual));
+  }
+
+  private static <T> Iterable<T> toIterable(Iterator<T> actual) {
+    Collection<T> actualList = new ArrayList<T>();
+    while(actual.hasNext()) {
+      actualList.add(actual.next());
+    }
+    return actualList;
   }
 }

--- a/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Iterator_Test.java
+++ b/src/test/java/org/fest/assertions/api/Assertions_assertThat_with_Iterator_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Created on Oct 18, 2010
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ * 
+ * Copyright @2010-2011 the original author or authors.
+ */
+package org.fest.assertions.api;
+
+import static java.util.Arrays.asList;
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.util.Sets.newLinkedHashSet;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.matchers.JUnitMatchers.hasItems;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link Assertions#assertThat(Iterator)}</code>.
+ * 
+ * @author Julien Meddah
+ * @author Joel Costigliola
+ */
+public class Assertions_assertThat_with_Iterator_Test {
+
+  @Test
+  public void should_create_Assert() {
+    IterableAssert<Object> assertions = Assertions.assertThat(newLinkedHashSet());
+    assertNotNull(assertions);
+  }
+
+  @Test
+  public void should_initialise_actual() {
+    Iterator<String> names = asList("Luke", "Leia").iterator();
+    IterableAssert<String> assertions = assertThat(names);
+    assertThat(assertions.actual, hasItems("Leia", "Luke"));
+  }
+}


### PR DESCRIPTION
In reference to http://code.google.com/p/fest/issues/detail?id=101
There is no way currently to call `Assertions.assertThat` with an `Iterator<T>` as parameter.
An user can still convert himself the iterator to an iterable, but he might as well use one more `assertThat` overload.
